### PR TITLE
Merge in 3.4.3 fixes

### DIFF
--- a/Components/Bot Components/Layers/SAIN Combat/Solo Actions/DogFight.cs
+++ b/Components/Bot Components/Layers/SAIN Combat/Solo Actions/DogFight.cs
@@ -35,7 +35,7 @@ namespace SAIN.Layers
             {
                 BotOwner.GoToPoint(pos, false, -1, false, false, false);
             }
-            else if (!EnemyVisible)
+            else if (!EnemyVisible && (SAIN.Enemy.Position - BotOwner.Position).sqrMagnitude > 2f)
             {
                 BotOwner.MoveToEnemyData.TryMoveToEnemy(SAIN.Enemy.Position);
             }

--- a/Components/Bot Components/Layers/SAIN Extract/ExtractAction.cs
+++ b/Components/Bot Components/Layers/SAIN Extract/ExtractAction.cs
@@ -13,10 +13,8 @@ namespace SAIN.Layers
 {
     internal class ExtractAction : CustomLogic
     {
-        private MethodInfo _BotUnspawn;
         public ExtractAction(BotOwner bot) : base(bot)
         {
-            _BotUnspawn = AccessTools.Method(bot.LeaveData.GetType(), "method_1");
             Logger = BepInEx.Logging.Logger.CreateLogSource(this.GetType().Name);
             SAIN = bot.GetComponent<SAINComponent>();
             Shoot = new ShootClass(bot, SAIN);
@@ -129,7 +127,12 @@ namespace SAIN.Layers
             if (ExtractTimer < Time.time)
             {
                 Logger.LogInfo($"{BotOwner.name} Extracted at {point} at {System.DateTime.UtcNow}");
-                _BotUnspawn.Invoke(BotOwner.LeaveData, null);
+
+                var botgame = Singleton<IBotGame>.Instance;
+                BotOwner.Deactivate();
+                BotOwner.Dispose();
+                botgame.BotUnspawn(BotOwner);
+                Object.Destroy(BotOwner);
             }
         }
 

--- a/Components/Bot Components/Layers/SAIN Extract/ExtractAction.cs
+++ b/Components/Bot Components/Layers/SAIN Extract/ExtractAction.cs
@@ -30,12 +30,12 @@ namespace SAIN.Layers
 
         public override void Start()
         {
-            BotOwner.PatrollingData.Pause();
+            BotOwner.PatrollingData?.Pause();
         }
 
         public override void Stop()
         {
-            BotOwner.PatrollingData.Unpause();
+            BotOwner.PatrollingData?.Unpause();
         }
 
         public override void Update()

--- a/Components/Bot Components/SAINComponent.cs
+++ b/Components/Bot Components/SAINComponent.cs
@@ -115,13 +115,13 @@ namespace SAIN.Components
         {
             if (LayersActive)
             {
-                BotOwner.PatrollingData.Pause();
+                BotOwner.PatrollingData?.Pause();
             }
             else
             {
                 if (Enemy == null)
                 {
-                    BotOwner.PatrollingData.Unpause();
+                    BotOwner.PatrollingData?.Unpause();
                 }
             }
         }

--- a/Components/Bot Components/SAINComponent.cs
+++ b/Components/Bot Components/SAINComponent.cs
@@ -201,6 +201,7 @@ namespace SAIN.Components
             Destroy(Hearing);
             Destroy(Talk);
             Destroy(Decision);
+            Destroy(Cover.CoverFinder);
             Destroy(Cover);
             Destroy(FlashLight);
             Destroy(SelfActions);

--- a/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
+++ b/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
@@ -4,6 +4,7 @@ using SAIN.Components;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using UnityEngine.UIElements;
 
 namespace SAIN.Classes
 {
@@ -28,6 +29,18 @@ namespace SAIN.Classes
             {
                 ClearEnemyTimer = Time.time + 1f;
                 ClearEnemies();
+            }
+
+            // If our current enemy no longer exists, clean up
+            if (Enemy?.EnemyPlayer == null || Enemy?.EnemyPlayer.AIData?.BotOwner == null)
+            {
+                Enemy = null;
+            }
+
+            // For extra sanity, if the GoalEnemy's person's BotOwner is null, reset that too
+            if (BotOwner.Memory.GoalEnemy?.Person?.AIData?.BotOwner == null)
+            {
+                BotOwner.Memory.GoalEnemy = null;
             }
 
             var goalEnemy = BotOwner.Memory.GoalEnemy;
@@ -84,7 +97,7 @@ namespace SAIN.Classes
                 foreach (string id in Enemies.Keys)
                 {
                     var enemy = Enemies[id];
-                    if (enemy == null || enemy.EnemyPlayer == null || enemy.EnemyPlayer?.HealthController?.IsAlive == false)
+                    if (enemy == null || enemy.EnemyPlayer == null || enemy.EnemyPlayer.AIData?.BotOwner == null || enemy.EnemyPlayer?.HealthController?.IsAlive == false)
                     {
                         EnemyIDsToRemove.Add(id);
                     }

--- a/Components/Bot Components/SubComponents/Grenade/BotGrenadeClass.cs
+++ b/Components/Bot Components/SubComponents/Grenade/BotGrenadeClass.cs
@@ -42,7 +42,7 @@ namespace SAIN.Classes
                 {
                     foreach (var tracker in ActiveGrenades)
                     {
-                        if (tracker?.Grenade?.transform != null && tracker?.GrenadeSpotted == true)
+                        if (tracker?.Grenade != null && tracker?.Grenade?.transform != null && tracker?.GrenadeSpotted == true)
                         {
                             return tracker.Grenade.transform.position;
                         }

--- a/Components/Bot Components/SubComponents/Info/InfoClass.cs
+++ b/Components/Bot Components/SubComponents/Info/InfoClass.cs
@@ -15,7 +15,7 @@ namespace SAIN.Classes
             Logger = BepInEx.Logging.Logger.CreateLogSource(GetType().Name);
 
             FindBotType();
-            PersonalityClass = new PersonalityClass(BotOwner);
+            PersonalityClass = new PersonalityClass(BotOwner, this);
             CalcHoldGroundDelay();
             CalcTimeBeforeSearch();
 

--- a/Components/Bot Components/SubComponents/Info/PersonalityClass.cs
+++ b/Components/Bot Components/SubComponents/Info/PersonalityClass.cs
@@ -14,8 +14,9 @@ namespace SAIN.Classes
 {
     public class PersonalityClass : SAINBot
     {
-        public PersonalityClass(BotOwner owner) : base(owner) 
+        public PersonalityClass(BotOwner owner, SAINBotInfo botInfo) : base(owner) 
         {
+            Info = botInfo;
             SetPersonality();
         }
 
@@ -72,7 +73,7 @@ namespace SAIN.Classes
             }
         }
 
-        private SAINBotInfo Info => SAIN.Info;
+        private SAINBotInfo Info;
 
         private bool CanBeChad
         {

--- a/Components/Bot Components/SubComponents/NoBushESP.cs
+++ b/Components/Bot Components/SubComponents/NoBushESP.cs
@@ -15,6 +15,9 @@ namespace SAIN.Classes
 
         private void Awake()
         {
+            // We include the "PlayerSpiritAura" mask to support Visceral Bodies, which replaces all foliage and grass with this layer
+            NoBushMask = (LayerMaskClass.HighPolyWithTerrainMaskAI | (1 << LayerMask.NameToLayer("PlayerSpiritAura")));
+
             SAIN = GetComponent<SAINComponent>();
             Logger = BepInEx.Logging.Logger.CreateLogSource(GetType().Name);
         }
@@ -85,7 +88,7 @@ namespace SAIN.Classes
             return false;
         }
 
-        private static LayerMask NoBushMask => LayerMaskClass.HighPolyWithTerrainMaskAI;
+        private LayerMask NoBushMask;
         public static List<string> ExclusionList = new List<string> { "filbert", "fibert", "tree", "pine", "plant", "birch", "collider",
         "timber", "spruce", "bush", "metal", "wood", "grass" };
     }

--- a/Components/Bot Components/SubComponents/SelfActionClass.cs
+++ b/Components/Bot Components/SubComponents/SelfActionClass.cs
@@ -22,7 +22,7 @@ namespace SAIN.Classes
         private SAINSelfDecision SelfDecision => SAIN.Decision.CurrentSelfDecision;
 
         private bool WasUsingMeds = false;
-        private bool UsingMeds => BotOwner.Medecine.Using;
+        private bool UsingMeds => BotOwner.Medecine?.Using == true;
 
         private void Update()
         {

--- a/Components/Bot Components/SubComponents/Sense/HearingSensorClass.cs
+++ b/Components/Bot Components/SubComponents/Sense/HearingSensorClass.cs
@@ -59,7 +59,12 @@ namespace SAIN.Classes
                     {
                         if (distance < 5f)
                         {
-                            BotOwner.Memory.Spotted(false, null, null);
+                            // Note: This can throw an exception sometimes, we'll just ignore it for now
+                            try
+                            {
+                                BotOwner.Memory.Spotted(false, null, null);
+                            }
+                            catch { }
                         }
 
                         ReactToSound(player, position, distance, true, type);

--- a/Components/Bot Components/SubComponents/Weapon/Firemode.cs
+++ b/Components/Bot Components/SubComponents/Weapon/Firemode.cs
@@ -46,14 +46,12 @@ namespace SAIN.Classes
 
                 if (mode != EFireMode.doublet && CurrentWeapon.SelectedFireMode != mode)
                 {
+                    CurrentWeapon.FireMode.SetFireMode(mode);
+
                     var animate = BotOwner.GetPlayer?.HandsController?.FirearmsAnimator;
                     if (animate != null)
                     {
                         BotOwner.GetPlayer.HandsController.FirearmsAnimator.SetFireMode(mode);
-                    }
-                    else
-                    {
-                        CurrentWeapon.FireMode.SetFireMode(mode);
                     }
                 }
                 else

--- a/Components/Bot Controller Components/Classes/BotSpawnController.cs
+++ b/Components/Bot Controller Components/Classes/BotSpawnController.cs
@@ -79,7 +79,6 @@ namespace SAIN.Components.BotController
                     SAINBotDictionary.Remove(bot.ProfileId);
                     if (bot.TryGetComponent<SAINComponent>(out var component))
                     {
-                        component.BotOwner.LeaveData.OnLeave -= RemoveBot;
                         component.Dispose();
                     }
                 }

--- a/Plugin/Config/Editor/EditorSettings.cs
+++ b/Plugin/Config/Editor/EditorSettings.cs
@@ -72,14 +72,27 @@ namespace SAIN.UserSettings
             FireratMulti = BindFloat(nameof(FireratMulti));
 
             // Personality
-            AllChads = BindBool(nameof(AllChads));
-            AllGigaChads = BindBool(nameof(AllGigaChads));
-            AllRats = BindBool(nameof(AllRats));
+            AllChads = BindBool(nameof(AllChads), null, false);
+            AllGigaChads = BindBool(nameof(AllGigaChads), null, false);
+            AllRats = BindBool(nameof(AllRats), null, false);
 
             RandomGigaChadChance = BindInt(nameof(RandomGigaChadChance), null, 3);
             RandomChadChance = BindInt(nameof(RandomChadChance), null, 3);
             RandomRatChance = BindInt(nameof(RandomRatChance), null, 30);
             RandomCowardChance = BindInt(nameof(RandomCowardChance), null, 30);
+
+            // NOTE: This is to resolve an issue where previous versions could result in "All*" all being true
+            //       If more than 1 "All" option is true, disable them all
+            int allPersonalityValuesEnabled = 0;
+            allPersonalityValuesEnabled += AllChads.Value ? 1 : 0;
+            allPersonalityValuesEnabled += AllGigaChads.Value ? 1 : 0;
+            allPersonalityValuesEnabled += AllRats.Value ? 1 : 0;
+            if (allPersonalityValuesEnabled > 1)
+            {
+                AllChads.Value = false;
+                AllGigaChads.Value = false;
+                AllRats.Value = false;
+            }
         }
 
         public static ConfigEntry<float> BindFloat(string name, string section = null, float defaultValue = 1f, ConfigDescription description = null)

--- a/SAIN.csproj
+++ b/SAIN.csproj
@@ -352,13 +352,6 @@
   <PropertyGroup>
     <PostBuildEvent>copy "$(TargetPath)" "$(ProjectDir)\..\..\BepInEx\plugins\$(TargetName)-$(ConfigurationName).dll"
 
-if $(ConfigurationName) == Debug (
-    copy "$(TargetDir)$(TargetName).pdb" "C:\Games\spt 3.5.7\BepInEx\plugins\$(TargetName).pdb"
-) else (
-    del "C:\Games\spt 3.5.7\BepInEx\plugins\$(TargetName).pdb"
-)
-)
-
 </PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Make sure to clean up the CoverFinder component off bot objects
- Don't need to remove the LeaveData.OnLeave hook, as that object gets cleaned up already on bot despawn
- Nullguard the `PatrollingData` and `Medecine` properties of BotOwner, as they are disposed before our components on raid end
- Unity components don't overload null guards, so add an explicit check on tracker.Grenade to make sure it's not null
- PersonalityClass depends on InfoClass, but it wasn't done being created before it was needed. So pass InfoClass directly into PersonalityClass
- Fix config if it ended up with multiple "All" personality options checked
- Utilize the same method for despawning bots as Donuts uses, fixes exceptions
- Add a try/catch around Memory.Spotted, as the BSG code throws an exception sometimes
- Modify NoBushESP to work with Visceral Bodies from the player perspective. Note: Bots can still see other bots through foliage, and will still "see" the player as a target through foliage, this is not something SAIN can really fix, as it's how Visceral Bodies changes foliage layers causing this
- Fix issue with some bots constantly trying to change fire mode (The base BSG code calls FireMode.SetFireMode AND Animator.SetFireMode, so we'll call them both too)
- Maybe fix spinning bots shooting the ground? There was an exception being thrown in TryMoveToEnemy when the source and target are super close, so make sure they aren't super close
- If the EnemyPlayer is null, or the EnemyPlayerBotOwner is null, reset the Enemy
- If the Bot's GoalEnemy's BotOwner is null, reset the Bot's GoalEnemy