### PR TITLE
Small fixes for search behavior: sprint+stop movement, steering madness

### DIFF
--- a/Layers/Combat/Solo/SearchAction.cs
+++ b/Layers/Combat/Solo/SearchAction.cs
@@ -150,7 +150,7 @@ namespace SAIN.Layers.Combat.Solo
             {
                 if (CanSeeDangerOrCorner(out Vector3 point))
                 {
-                    SAIN.Steering.LookToPoint(point + Vector3.up);
+                    SAIN.Steering.LookToPoint(point);
                 }
                 else
                 {
@@ -162,44 +162,50 @@ namespace SAIN.Layers.Combat.Solo
         private bool CanSeeDangerOrCorner(out Vector3 point)
         {
             point = Vector3.zero;
+            
             if (Search.SearchMovePoint == null || Search.CurrentState == ESearchMove.MoveToDangerPoint)
             {
-                _LookPoint = Vector3.zero;
+                LookPoint = Vector3.zero;
                 return false;
             }
+            
             if (CheckSeeTimer < Time.time)
             {
-                _LookPoint = Vector3.zero;
-                CheckSeeTimer = Time.time + 0.3f;
-                Vector3 start = SAIN.Position;
+                LookPoint = Vector3.zero;
+                CheckSeeTimer = Time.time + 1f * Random.Range(0.66f, 1.33f);
+                var headPosition = SAIN.Transform.Head;
 
-                _CanSeeDanger = !Vector.Raycast(start,
+                var canSeePoint = !Vector.Raycast(headPosition,
                     Search.SearchMovePoint.DangerPoint,
                     LayerMaskClass.HighPolyWithTerrainMaskAI);
 
-                if (_CanSeeDanger)
+                if (canSeePoint)
                 {
-                    _CanSeeCorner = false;
-                    _LookPoint = Search.SearchMovePoint.DangerPoint;
+                    LookPoint = Search.SearchMovePoint.DangerPoint;
                 }
                 else
                 {
-                    _CanSeeCorner = !Vector.Raycast(start,
+                    canSeePoint = !Vector.Raycast(headPosition,
                         Search.SearchMovePoint.Corner,
                         LayerMaskClass.HighPolyWithTerrainMaskAI);
-                    if (_CanSeeCorner)
+                    if (canSeePoint)
                     {
-                        _LookPoint = Search.SearchMovePoint.Corner;
+                        LookPoint = Search.SearchMovePoint.Corner;
                     }
                 }
+                
+                if (LookPoint != Vector3.zero)
+                {
+                    LookPoint.y = 0;
+                    LookPoint += headPosition;
+                }
             }
-            point = _LookPoint;
-            return _CanSeeDanger || _CanSeeCorner;
+            
+            point = LookPoint;
+            return point != Vector3.zero;
         }
 
-        private bool _CanSeeCorner;
-        private bool _CanSeeDanger;
-        private Vector3 _LookPoint;
+        private Vector3 LookPoint;
         private float CheckSeeTimer;
 
         private bool SteerByPriority(bool value) => SAIN.Steering.SteerByPriority(value);

--- a/SAINComponent/Classes/SAINSearchClass.cs
+++ b/SAINComponent/Classes/SAINSearchClass.cs
@@ -199,6 +199,9 @@ namespace SAIN.SAINComponent.Classes
         private void MoveToPoint(bool shallSprint)
         {
             RecalcPathTimer = Time.time + 2;
+
+            SAIN.Mover.Sprint(shallSprint);
+            
             if (shallSprint)
             {
                 BotOwner.BotRun.Run(ActiveDestination, false);


### PR DESCRIPTION
## Issue

When bots are in search state, sometimes they act weird when try to move to another point. It looks like they are starting to sprint and immediately stop, producing weird sounds which breaks "immersion" IMO.
Example:


https://github.com/DrakiaXYZ/SAIN/assets/135702/8c03fe26-1944-48d6-a682-11dbdb73c592

## How to reproduce

Most easier way to make the issue more noticeable is to ramp up the aggressiveness of bots and set them to be chads/gigachads only, because then they tend to sprint way more often

The issue happens because sometimes bots can switch to search state from other state, **while they are sprinting**. This leaves them stuck with sprinting enabled, while their move to some point calculated to be made without sprinting

Example after sprinting fix:

https://github.com/DrakiaXYZ/SAIN/assets/135702/63d71458-b600-4b2f-a594-122060aa74d7

On the video above you can see that they have smooth movement now, but also you can see that they have an **insane steering once they reach the destination point**. That's the second thing I've fixed with this PR.

Final results, sprinting + steering fixed:

https://i.imgur.com/qh92x0x.mp4

https://i.imgur.com/MID9ZQI.mp4

