### PR TITLE
Updated CheckTimeRemaining() to Use SPT 3.7.4 Methods that Support Scav Raids

### DIFF
--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -57,6 +57,11 @@ namespace SAIN.Components.BotController
 
         private bool GetExfilControl()
         {
+            if (Singleton<AbstractGame>.Instance?.GameTimer == null)
+            {
+                return false;
+            }
+
             if (ExfilController == null)
             {
                 ExfilController = Singleton<GameWorld>.Instance.ExfiltrationController;
@@ -300,23 +305,19 @@ namespace SAIN.Components.BotController
 
         public void CheckTimeRemaining()
         {
-            var GameTime = Singleton<AbstractGame>.Instance?.GameTimer;
-            if (GameTime?.StartDateTime != null && GameTime?.EscapeDateTime != null)
-            {
-                var StartTime = GameTime.StartDateTime.Value;
-                var EscapeTime = GameTime.EscapeDateTime.Value;
-                var Span = EscapeTime - StartTime;
-                TotalRaidTime = (float)Span.TotalSeconds;
-                TimeRemaining = EscapeTimeSeconds(GameTime);
-                float ratio = TimeRemaining / TotalRaidTime;
-                PercentageRemaining = Mathf.Round(ratio * 100f);
-            }
-        }
+            TotalRaidTime = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds;
 
-        public float EscapeTimeSeconds(GameTimerClass timer)
-        {
-            DateTime? escapeDateTime = timer.EscapeDateTime;
-            return (float)((escapeDateTime != null) ? (escapeDateTime.Value - HelpersGClass.UtcNow) : TimeSpan.MaxValue).TotalSeconds;
+            //if (Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.HasRaidStarted())
+            if (Singleton<AbstractGame>.Instance.GameTimer.Started())
+            {
+                TimeRemaining = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRemainingRaidSeconds();
+                PercentageRemaining = Aki.SinglePlayer.Utils.InRaid.RaidTimeUtil.GetRaidTimeRemainingFraction() * 100;
+            }
+            else
+            {
+                TimeRemaining = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.NewEscapeTimeSeconds;
+                PercentageRemaining = 100f * TimeRemaining / TotalRaidTime;
+            }
         }
     }
 }

--- a/SAIN.csproj
+++ b/SAIN.csproj
@@ -108,6 +108,9 @@
     <Reference Include="0Harmony">
       <HintPath>..\..\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
+    <Reference Include="aki-singleplayer">
+      <HintPath>..\..\BepInEx\plugins\spt\aki-singleplayer.dll</HintPath>
+    </Reference>
     <Reference Include="Aki.Build, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\EscapeFromTarkov_Data\Managed\Aki.Build.dll</HintPath>


### PR DESCRIPTION
Updated `CheckTimeRemaining()` in `BotExtractManager` to use methods in SPT 3.7.4 for calculating raid times including adjustments for Scav raids. The commented line with the `HasRaidStarted()` method can be used with SPT 3.7.4 with the 2023/12/06 hotfix or later.

I added a `Singleton<AbstractGame>.Instance?.GameTimer` check in `GetExfilControl()` because the `Update()` method starts very early and throws an exception without it. 

In one of my test raids, I spawned very late into a raid and a PMC went to extract almost immediately. Before this change, the PMC would have stayed in the raid until it was MIA. 

For this PR to work, **SPT 3.7.4 or later is required.**