### PR TITLE
Bot Extract Improvements

### DIFF
--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -180,6 +180,12 @@ namespace SAIN.Components.BotController
                 {
                     if (ex != null && ex.isActiveAndEnabled && !ValidScavExfils.ContainsKey(ex))
                     {
+                        if (ex.Status == EExfiltrationStatus.NotPresent)
+                        {
+                            //Logger.LogInfo($"Extraction {ex.Settings.Name} is unavailable");
+                            continue;
+                        }
+
                         if (ex.TryGetComponent<Collider>(out var collider))
                         {
                             if (bot.Mover.CanGoToPoint(collider.transform.position, out Vector3 Destination, true, 3f))
@@ -199,6 +205,12 @@ namespace SAIN.Components.BotController
                         // ex.isActiveAndEnabled && 
                         if (ex != null && !ValidExfils.ContainsKey(ex))
                         {
+                            if (ex.Status == EExfiltrationStatus.NotPresent)
+                            {
+                                //Logger.LogInfo($"Extraction {ex.Settings.Name} is unavailable");
+                                continue;
+                            }
+
                             if (ex.TryGetComponent<Collider>(out var collider))
                             {
                                 if (bot.Mover.CanGoToPoint(collider.transform.position, out Vector3 Destination, true))
@@ -208,13 +220,13 @@ namespace SAIN.Components.BotController
                                 else
                                 {
                                     if (SAINPlugin.DebugMode)
-                                        Logger.LogWarning($"Could not find valid path to {ex.name}");
+                                        Logger.LogWarning($"Could not find valid path to {ex.Settings.Name}");
                                 }
                             }
                             else
                             {
                                 if (SAINPlugin.DebugMode)
-                                    Logger.LogWarning($"Could not find collider for {ex.name}");
+                                    Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
                             }
                         }
                         else if (ex == null)

--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -422,6 +422,8 @@ namespace SAIN.Components.BotController
                                 {
                                     member.Value.Memory.ExfilPosition = bot.Memory.ExfilPosition;
                                 }
+
+                                member.Value.Memory.ExfilPoint = bot.Memory.ExfilPoint;
                             }
                         }
                     }
@@ -433,7 +435,7 @@ namespace SAIN.Components.BotController
                 bot.Memory.ExfilPosition = squad.LeaderComponent?.Memory.ExfilPosition;
             }
 
-            return bot.Memory.ExfilPoint != null;
+            return (bot.Memory.ExfilPosition != null) && (bot.Memory.ExfilPoint != null);
         }
 
         private float CheckExtractTimer = 0f;

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -118,7 +118,7 @@ namespace SAIN.Layers
         {
             if (ExtractTimer == -1f)
             {
-                float timer = 5f * Random.Range(0.75f, 1.5f);
+                float timer = SAIN.Memory.ExfilPoint.Settings.ExfiltrationTime;
                 ExtractTimer = Time.time + timer;
 
                 Logger.LogInfo($"{BotOwner.name} Starting Extract Timer of {timer}");
@@ -126,7 +126,7 @@ namespace SAIN.Layers
 
             if (ExtractTimer < Time.time)
             {
-                Logger.LogInfo($"{BotOwner.name} Extracted at {point} at {System.DateTime.UtcNow}");
+                Logger.LogInfo($"{BotOwner.name} Extracted at {point} for extract {SAIN.Memory.ExfilPoint.Settings.Name} at {System.DateTime.UtcNow}");
 
                 var botgame = Singleton<IBotGame>.Instance;
                 Player player = SAIN.Player;

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -130,8 +130,9 @@ namespace SAIN.Layers
 
                     NavMeshPathStatus pathStatus = BotOwner.Mover.GoToPoint(point, true, 0.5f, false, false);
                     float distanceToEndOfPath = Vector3.Distance(BotOwner.Position, BotOwner.Mover.CurPathLastPoint);
+                    bool reachedEndOfIncompletePath = (pathStatus == NavMeshPathStatus.PathPartial) && (distanceToEndOfPath < BotExtractManager.MinDistanceToExtract);
 
-                    if ((pathStatus == NavMeshPathStatus.PathInvalid) || (distanceToEndOfPath < BotExtractManager.MinDistanceToExtract))
+                    if ((pathStatus == NavMeshPathStatus.PathInvalid) || reachedEndOfIncompletePath)
                     {
                         BotController.BotExtractManager.ResetExfilSearchTime(SAIN);
                         SAIN.Memory.ExfilPoint = null;

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -123,7 +123,7 @@ namespace SAIN.Layers
         {
             if (ExtractTimer == -1f)
             {
-                ExtractTimer = BotExtractManager.GetExfilTime(SAIN.Memory.ExfilPoint);
+                ExtractTimer = BotController.BotExtractManager.GetExfilTime(SAIN.Memory.ExfilPoint);
                 float timeRemaining = ExtractTimer - Time.time;
 
                 activateExfil(SAIN.Memory.ExfilPoint);

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -192,7 +192,7 @@ namespace SAIN.Layers
                     case EExfiltrationType.SharedTimer:
                         exfil.SetStatusLogged(EExfiltrationStatus.Countdown, "Proceed-1");
 
-                        //if (SAINPlugin.DebugMode)
+                        if (SAINPlugin.DebugMode)
                         {
                             Logger.LogInfo($"bot {SAIN.name} has started the VEX exfil");
                         }

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -37,10 +37,13 @@ namespace SAIN.Layers
                 return false;
             }
 
+            // If the bot can no longer use its selected extract and isn't already in the extract area, select another one. This typically happens if
+            // the bot selects a VEX but the car leaves before the bot reaches it.
             if (!BotController.BotExtractManager.CanUseExtract(SAIN.Memory.ExfilPoint) && !IsInExtractArea())
             {
                 SAIN.Memory.ExfilPoint = null;
                 SAIN.Memory.ExfilPosition = null;
+
                 return false;
             }
 

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -1,5 +1,6 @@
 ﻿using EFT;
 using SAIN.Components.BotController;
+using SAIN.Layers.Combat.Solo;
 
 namespace SAIN.Layers
 {

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -36,6 +36,18 @@ namespace SAIN.Layers
                 return false;
             }
 
+            if (BotExtractManager.GetTimeRemainingForExfil(SAIN.Memory.ExfilPoint) == 0)
+            {
+                float distance = (BotOwner.Position - SAIN.Memory.ExfilPosition.Value).sqrMagnitude;
+
+                if (distance > ExtractAction.MinDistanceToStartExtract)
+                {
+                    SAIN.Memory.ExfilPoint = null;
+                    SAIN.Memory.ExfilPosition = null;
+                    return false;
+                }
+            }
+
             return true;
         }
 

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -1,4 +1,5 @@
 ﻿using EFT;
+using SAIN.Components.BotController;
 
 namespace SAIN.Layers
 {
@@ -19,12 +20,23 @@ namespace SAIN.Layers
         {
             if (SAIN == null) return false;
 
-            if (SAIN.Memory.ExfilPosition == null || !SAIN.Info.FileSettings.Mind.EnableExtracts)
+            if (!SAIN.Info.FileSettings.Mind.EnableExtracts)
             {
                 return false;
             }
 
-            return ExtractFromTime() || ExtractFromInjury() || ExtractFromLoot() || ExtractFromExternal();
+            if (!ExtractFromTime() && !ExtractFromInjury() && !ExtractFromLoot() && !ExtractFromExternal())
+            {
+                return false;
+            }
+
+            if (SAIN.Memory.ExfilPosition == null)
+            {
+                BotExtractManager.TryFindExfilForBot(SAIN);
+                return false;
+            }
+
+            return true;
         }
 
         private bool ExtractFromTime()

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -1,6 +1,5 @@
 ﻿using EFT;
-using SAIN.Components.BotController;
-using SAIN.Layers.Combat.Solo;
+using UnityEngine.UIElements;
 
 namespace SAIN.Layers
 {
@@ -22,6 +21,11 @@ namespace SAIN.Layers
             if (SAIN == null) return false;
 
             if (!SAIN.Info.FileSettings.Mind.EnableExtracts)
+            {
+                return false;
+            }
+
+            if (!BotController.BotExtractManager.IsBotAllowedToExfil(SAIN))
             {
                 return false;
             }

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -32,23 +32,24 @@ namespace SAIN.Layers
 
             if (SAIN.Memory.ExfilPosition == null)
             {
-                BotExtractManager.TryFindExfilForBot(SAIN);
+                BotController.BotExtractManager.TryFindExfilForBot(SAIN);
                 return false;
             }
 
-            if (BotExtractManager.GetTimeRemainingForExfil(SAIN.Memory.ExfilPoint) == 0)
+            if (!BotController.BotExtractManager.CanUseExtract(SAIN.Memory.ExfilPoint) && !IsInExtractArea())
             {
-                float distance = (BotOwner.Position - SAIN.Memory.ExfilPosition.Value).sqrMagnitude;
-
-                if (distance > ExtractAction.MinDistanceToStartExtract)
-                {
-                    SAIN.Memory.ExfilPoint = null;
-                    SAIN.Memory.ExfilPosition = null;
-                    return false;
-                }
+                SAIN.Memory.ExfilPoint = null;
+                SAIN.Memory.ExfilPosition = null;
+                return false;
             }
 
             return true;
+        }
+
+        private bool IsInExtractArea()
+        {
+            float distance = (BotOwner.Position - SAIN.Memory.ExfilPosition.Value).sqrMagnitude;
+            return distance < ExtractAction.MinDistanceToStartExtract;
         }
 
         private bool ExtractFromTime()

--- a/SAINComponent/Classes/SAINEnemyClass.cs
+++ b/SAINComponent/Classes/SAINEnemyClass.cs
@@ -107,7 +107,7 @@ namespace SAIN.SAINComponent.Classes
 
             bool visible = false;
             bool canshoot = false;
-            bool usingLight = EnemyPlayer?.AIData?.UsingLight == true && Enemy?.Path != null && Enemy.EnemyTransform?.TransformNull == false && Enemy.Path.EnemyDistance < 50f;
+            bool usingLight = EnemyPlayer?.AIData?.UsingLight == true && Enemy?.Path != null && Enemy?.EnemyTransform?.TransformNull == false && Enemy?.Path?.EnemyDistance < 50f;
 
             if (CheckLosTimer < Time.time)
             {

--- a/SAINComponent/Classes/SAINMemoryClass.cs
+++ b/SAINComponent/Classes/SAINMemoryClass.cs
@@ -1,4 +1,5 @@
 ﻿using EFT;
+using EFT.Interactive;
 using SAIN.SAINComponent.Classes.Decision;
 using System;
 using System.Collections.Generic;
@@ -48,6 +49,7 @@ namespace SAIN.SAINComponent.Classes
         private float UpdateHealthTimer = 0f;
 
         public Vector3? ExfilPosition { get; set; }
+        public ExfiltrationPoint ExfilPoint { get; set; }
         public bool CannotExfil { get; set; }
 
         public bool Healthy => HealthStatus == ETagStatus.Healthy;

--- a/SAINComponent/Classes/SAINMemoryClass.cs
+++ b/SAINComponent/Classes/SAINMemoryClass.cs
@@ -50,7 +50,6 @@ namespace SAIN.SAINComponent.Classes
 
         public Vector3? ExfilPosition { get; set; }
         public ExfiltrationPoint ExfilPoint { get; set; }
-        public bool CannotExfil { get; set; }
 
         public bool Healthy => HealthStatus == ETagStatus.Healthy;
         public bool Injured => HealthStatus == ETagStatus.Injured;

--- a/SAINComponent/Classes/SAINSearchClass.cs
+++ b/SAINComponent/Classes/SAINSearchClass.cs
@@ -188,7 +188,7 @@ namespace SAIN.SAINComponent.Classes
         private Vector3 NextCorner()
         {
             int i = Index;
-            if (Path.corners.Length < i)
+            if (Path.corners.Length > i)
             {
                 Index++;
                 return Path.corners[i];

--- a/SAINComponent/PersonBase/SAINPersonTransformClass.cs
+++ b/SAINComponent/PersonBase/SAINPersonTransformClass.cs
@@ -20,7 +20,7 @@ namespace SAIN.SAINComponent.BaseClasses
 
         private readonly SAINPersonClass Person;
         public bool TransformNull => Person == null || Person.PlayerNull || DefaultTransform == null || Person?.Player?.gameObject == null;
-        public BifacialTransform DefaultTransform => Person.IPlayer.Transform;
+        public BifacialTransform DefaultTransform => Person?.IPlayer?.Transform;
         public Vector3 Position => !TransformNull ? DefaultTransform.position : Vector3.zero;
         public Vector3 LookDirection => !TransformNull ? Person.IPlayer.LookDirection : Vector3.zero;
 


### PR DESCRIPTION
**Made the following improvements to bot extract behavior:**
* Eliminated extracts that are unrealistic for bots to use (see details below)
* Extracts are assigned to bots as needed instead of shortly after they spawn. This allows some extract locations to become available throughout the raid (i.e. ZB013). 
* Use the actual extract exfiltration time, not a generic one
* If bots take the car extract, the car actually leaves when they extract. The extract will then appear in red font for you. 
* If an extract becomes unavailable when a bot in en route to it, the bot will select another extract instead
* If a bot cannot find a complete path to its extract (and reaches the end of the incomplete path), it will select another one instead
* If an extract cannot be found for a bot, check again every 10s until one is found. Previously, SAIN would give up immediately. 
* Lots of refactoring

**The following changes were made to available extracts:**
* Blacklisted extracts that are not available on the map (based on chance)
* Blacklisted co-op extracts (difficult to realistically use)
* Blacklisted train extracts (fundamentally possible to use, but bots get stuck on the train)
* Blacklisted extracts that require "world events" (namely switches) to use
* [No Change] Ignore equipment requirements for extracts (i.e. no-backpack extracts)

**Made the following additional improvements:**
* Fixed some causes of `SAINPersonTransformClass.TransformNull` NRE's (but other causes still remain)
* Fixed incorrect search behavior and fixed index-out-of-range exception in `SAINSearchClass.NextCorner()`

**Tested and confirmed the following:**
* PMC's have extracts available on all maps
* Scavs have extracts available on Customs
* Bosses never extract
* Squad extracts work correctly
* Car extracts work correctly

**Because this is a significant change, beta testing is probably a good idea before releasing this.**

**Known issues:**
* [Existing Issue] Some `SAINPersonTransformClass.TransformNull` NRE's still occur when bots extract
* [Existing Issue] Some `FirearmController` exceptions still occur when bots extract
* [Existing Issue] Bots get stuck on cars and trains at extracts because they don't have `NavMeshObstacles`
* [Existing Issue] Bots have trouble finding the Hangar Gate extract location on Labs
* [Existing Issue] Bots can use extracts that are available based on chance but appear unavailable to you (i.e. Smuggler's Boat). This is because EFT disables groups of objects (like the campfire for Smuggler's Boat) when the extract is unavailable to you. 
* Some maps like Reserve and Labs have limited extracts available for bots because many have restrictions that SAIN cannot resolve
* Bots sometimes (but rarely) get stuck when trying to extract. There are no exceptions when this happens, so I'm not sure what causes it. 