### PR TITLE
Add a path check when finding extracts

### DIFF
--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -357,9 +357,11 @@ namespace SAIN.Components.BotController
         {
             // Check each valid extract to ensure the bot can use it and that it isn't too close. If this method is called when a bot is near an extract, it might be because
             // it got stuck. 
+            NavMeshPath Path = new NavMeshPath();
             IDictionary<T, Vector3> possibleExfils = validExfils
                     .Where(x => CanUseExtract(x.Key))
                     .Where(x => Vector3.Distance(bot.Position, x.Value) > MinDistanceToExtract)
+                    .Where(x => NavMesh.CalculatePath(bot.Position, x.Value, -1, Path) && Path.status == NavMeshPathStatus.PathComplete)
                     .ToDictionary(x => x.Key, x => x.Value);
 
             if (!possibleExfils.Any())


### PR DESCRIPTION
Have found that this eliminates any pathing issues that extracting bots have with minimal overhead.