### PR TITLE
Extract Accuracy Improvements

### DIFF
--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -168,6 +168,8 @@ namespace SAIN.Components.BotController
                 return false;
             }
 
+            Logger.LogInfo($"{bot.name} has selected {bot.Memory.ExfilPoint.Settings.Name} for extraction");
+
             return true;
         }
 
@@ -181,7 +183,7 @@ namespace SAIN.Components.BotController
             return true;
         }
 
-        public bool TryAssignExfilForBot(SAINComponentClass bot)
+        private bool TryAssignExfilForBot(SAINComponentClass bot)
         {
             IDictionary<ExfiltrationPoint, Vector3> validExfils = GameWorldHandler.SAINGameWorld.ExtractFinder.GetValidExfilsForBot(bot);
             bot.Memory.ExfilPoint = selectExfilForBot(bot, validExfils);
@@ -197,7 +199,7 @@ namespace SAIN.Components.BotController
             // it got stuck. 
             NavMeshPath path = new NavMeshPath();
             IDictionary<ExfiltrationPoint, Vector3> possibleExfils = validExfils
-                    .Where(x => CanUseExtract(x.Key))
+                    .Where(x => CanBotsUseExtract(x.Key))
                     .Where(x => Vector3.Distance(bot.Position, x.Value) > MinDistanceToExtract)
                     .Where(x => NavMesh.CalculatePath(bot.Position, x.Value, -1, path) && (path.status == NavMeshPathStatus.PathComplete))
                     .ToDictionary(x => x.Key, x => x.Value);
@@ -223,7 +225,7 @@ namespace SAIN.Components.BotController
             return selectedExfil.Key;
         }
 
-        public bool CanUseExtract(ExfiltrationPoint exfil)
+        public bool CanBotsUseExtract(ExfiltrationPoint exfil)
         {
             // Only use the extract if it's available in the raid
             // NOTE: Extracts unavailable for you are disabled (exfil.isActiveAndEnabled = false), but we can't use that property because all PMC extracts may be disabled if
@@ -270,7 +272,7 @@ namespace SAIN.Components.BotController
             return true;
         }
 
-        public bool TryAssignSquadExfil(SAINComponentClass bot)
+        private bool TryAssignSquadExfil(SAINComponentClass bot)
         {
             var squad = bot.Squad;
             if (squad.IAmLeader)
@@ -321,7 +323,7 @@ namespace SAIN.Components.BotController
         public float TimeRemaining { get; private set; } = 999f;
         public float PercentageRemaining { get; private set; } = 100f;
 
-        public void CheckTimeRemaining()
+        private void CheckTimeRemaining()
         {
             TotalRaidTime = Aki.SinglePlayer.Utils.InRaid.RaidChangesUtil.OriginalEscapeTimeSeconds;
 

--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -11,6 +11,9 @@ using SAIN.Helpers;
 using System.Collections;
 using System.Reflection;
 using HarmonyLib;
+using Unity.Jobs;
+using Unity.Collections;
+using UnityEngine.UIElements;
 
 namespace SAIN.Components.BotController
 {
@@ -18,12 +21,11 @@ namespace SAIN.Components.BotController
     {
         public BotExtractManager() { }
 
-        public ExfiltrationControllerClass ExfilController { get; private set; }
         public float TotalRaidTime { get; private set; }
         
         public void Update()
         {
-            if (!GetExfilControl())
+            if (Singleton<AbstractGame>.Instance?.GameTimer == null)
             {
                 return;
             }
@@ -33,57 +35,8 @@ namespace SAIN.Components.BotController
                 return;
             }
 
-            CheckRaidProgressTimer = Time.time + 5f;
-
             CheckTimeRemaining();
-
-            if (DebugCheckExfilTimer < Time.time)
-            {
-                DebugCheckExfilTimer = Time.time + 30f;
-                Logger.LogInfo(
-                    $"Seconds Remaining in Raid: [{TimeRemaining}] Percentage of Raid Remaining: [{PercentageRemaining}]. " +
-                    $"Total Raid Seconds: [{TotalRaidTime}] " +
-                    $"Found: [{ValidScavExfils.Count}] ScavExfils and " +
-                    $"[{ValidExfils.Count}] PMC Exfils to be used."
-                    );
-                // Logger.LogInfo(
-                //     $"Total PMC Exfils on this map: [{AllExfils?.Length}] and " +
-                //     $"[{AllScavExfils?.Length}] Total Scav Exfils")
-                //     ;
-            }
-        }
-
-        private bool GetExfilControl()
-        {
-            if (Singleton<AbstractGame>.Instance?.GameTimer == null)
-            {
-                return false;
-            }
-
-            if (ExfilController == null)
-            {
-                ExfilController = Singleton<GameWorld>.Instance.ExfiltrationController;
-            }
-            else
-            {
-                if (AllScavExfils == null)
-                {
-                    AllScavExfils = ExfilController.ScavExfiltrationPoints;
-                    if (SAINPlugin.DebugMode && AllScavExfils != null)
-                    {
-                        Logger.LogInfo($"Found {AllScavExfils?.Length} possible Scav Exfil Points in this map.");
-                    }
-                }
-                if (AllExfils == null)
-                {
-                    AllExfils = ExfilController.ExfiltrationPoints;
-                    if (SAINPlugin.DebugMode && AllExfils != null)
-                    {
-                        Logger.LogInfo($"Found {AllExfils?.Length} possible Exfil Points in this map.");
-                    }
-                }
-            }
-            return ExfilController != null;
+            CheckRaidProgressTimer = Time.time + 5f;
         }
 
         private Dictionary<ExfiltrationPoint, float> exfilActivationTimes = new Dictionary<ExfiltrationPoint, float>();
@@ -143,203 +96,6 @@ namespace SAIN.Components.BotController
             return exfilTime;
         }
 
-        private float DebugCheckExfilTimer = 0f;
-        public ScavExfiltrationPoint[] AllScavExfils { get; private set; }
-        public Dictionary<ScavExfiltrationPoint, Vector3> ValidScavExfils { get; private set; } = new Dictionary<ScavExfiltrationPoint, Vector3>();
-
-        public ExfiltrationPoint[] AllExfils { get; private set; }
-        public Dictionary<ExfiltrationPoint, Vector3> ValidExfils { get; private set; } = new Dictionary<ExfiltrationPoint, Vector3>();
-
-        public bool IsFindingAllValidExfilsForAllBots { get; private set; } = false;
-
-        public IEnumerator EnumerateAllValidExfilsForAllBots()
-        {
-            if (Bots == null)
-            {
-                yield break;
-            }
-
-            try
-            {
-                IsFindingAllValidExfilsForAllBots = true;
-
-                foreach (string botKey in Bots.Keys.ToArray())
-                {
-                    if (!Bots.ContainsKey(botKey))
-                    {
-                        continue;
-                    }
-
-                    yield return FindAllValidExfilsForBot(Bots[botKey]);
-                }
-            }
-            finally
-            {
-                IsFindingAllValidExfilsForAllBots = false;
-            }
-        }
-
-        private IEnumerator FindAllValidExfilsForBot(SAINComponentClass bot)
-        {
-            if (bot.IsDead)
-            {
-                yield break;
-            }
-
-            if (bot.Info.Profile.IsScav)
-            {
-                yield return FindAllValidExfilsForBot(bot, ValidScavExfils, AllScavExfils);
-            }
-
-            yield return FindAllValidExfilsForBot(bot, ValidExfils, AllExfils);
-        }
-
-        private static FieldInfo colliderField = AccessTools.Field(typeof(ExfiltrationPoint), "_collider");
-        private static float defaultExtractNavMeshSearchRadius = 3f;
-
-        private IEnumerator FindAllValidExfilsForBot<T>(SAINComponentClass bot, IDictionary<T, Vector3> validExfils, T[] allExfils) where T : ExfiltrationPoint
-        {
-            if (bot == null)
-            {
-                yield break;
-            }
-
-            if (allExfils == null)
-            {
-                yield break;
-            }
-
-            foreach (var ex in allExfils)
-            {
-                if (validExfils.ContainsKey(ex))
-                {
-                    continue;
-                }
-
-                yield return null;
-
-                Vector3? Destination = GetTargetPositionForExtract(bot, ex);
-                if (Destination == null)
-                {
-                    continue;
-                }
-
-                validExfils.Add(ex, Destination.Value);
-            }
-        }
-
-        private static Vector3? GetTargetPositionForExtract(SAINComponentClass bot, ExfiltrationPoint ex)
-        {
-            if (ex == null)
-            {
-                if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Exfil is null in list!");
-
-                return null;
-            }
-
-            BoxCollider collider = (BoxCollider)colliderField.GetValue(ex);
-            if (collider == null)
-            {
-                if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
-
-                return null;
-            }
-
-            float searchRadius = Math.Min(Math.Min(collider.size.x, collider.size.y), collider.size.z) / 2;
-            if (searchRadius == 0)
-            {
-                searchRadius = defaultExtractNavMeshSearchRadius;
-
-                //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Collider size of {ex.Settings.Name} is (0, 0, 0). Using {searchRadius}m to check accessibility.");
-            }
-
-            IEnumerable<Vector3> colliderTestPoints = GetExtractTestPoints(collider, searchRadius, 1);
-            if (!colliderTestPoints.Any())
-            {
-                colliderTestPoints = Enumerable.Repeat(collider.transform.position, 1);
-
-                //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not create test points. Using collider position instead");
-            }
-
-            searchRadius += 0.5f;
-
-            Vector3 Destination = Vector3.positiveInfinity;
-            bool foundPoint = false;
-            foreach (Vector3 testPoint in colliderTestPoints)
-            {
-                //Bounds colliderBounds = new Bounds(collider.transform.position, collider.size);
-
-                //if (SAINPlugin.DebugMode)
-                    //Logger.LogInfo($"Testing position {testPoint} for {ex.Settings.Name} at {colliderBounds.min}-{colliderBounds.max} using search radius {searchRadius}m");
-
-                if (bot.Mover.CanGoToPoint(testPoint, out Destination, true, searchRadius))
-                {
-                    foundPoint = true;
-                    break;
-                }
-            }
-
-            if (!foundPoint)
-            {
-                //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not find valid path to {ex.Settings.Name} of using search radius {searchRadius}m");
-
-                return null;
-            }
-
-            //if (SAINPlugin.DebugMode)
-                Logger.LogInfo($"Found extract postion {Destination} for {ex.Settings.Name} using search radius {searchRadius}m");
-
-            return Destination;
-        }
-
-        private static IEnumerable<Vector3> GetExtractTestPoints(BoxCollider collider, float radius, float overlap)
-        {
-            Bounds colliderBounds = new Bounds(collider.transform.position, collider.size);
-
-            IEnumerable<Vector3> colliderTestPoints = GetRelativeExtractTestPoints(colliderBounds, radius, overlap);
-            return colliderTestPoints;
-        }
-
-        private static IEnumerable<Vector3> GetRelativeExtractTestPoints(Bounds colliderBounds, float radius, float overlap)
-        {
-            float minExtent = Math.Min(Math.Min(colliderBounds.size.x, colliderBounds.size.x), colliderBounds.size.x) / 2;
-            if (minExtent < radius)
-            {
-                Logger.LogWarning($"Radius {radius} is smaller than min collider extent {minExtent}");
-                return Enumerable.Empty<Vector3>();
-            }
-
-            Vector3 origin = new Vector3(colliderBounds.min.x + radius, colliderBounds.min.y + radius, colliderBounds.min.z + radius);
-
-            List<Vector3> testPoints = new List<Vector3>();
-
-            int widthCount = (int)Math.Max(1, Math.Ceiling((colliderBounds.size.x - (radius * 2)) / (2 * radius * overlap)));
-            int lengthCount = (int)Math.Max(1, Math.Ceiling((colliderBounds.size.z - (radius * 2)) / (2 * radius * overlap)));
-            int heightCount = (int)Math.Max(1, Math.Ceiling((colliderBounds.size.y - (radius * 2)) / (2 * radius * overlap)));
-
-            float widthSpacing = Math.Max(0, (colliderBounds.size.x - (radius * 2)) / widthCount);
-            float lengthSpacing = Math.Max(0, (colliderBounds.size.z - (radius * 2)) / lengthCount);
-            float heightSpacing = Math.Max(0, (colliderBounds.size.y - (radius * 2)) / heightCount);
-
-            for (int x = 0; x <= widthCount; x++)
-            {
-                for (int y = 0; y <= heightCount; y++)
-                {
-                    for (int z = 0; z <= lengthCount; z++)
-                    {
-                        testPoints.Add(new Vector3(origin.x + (widthSpacing * x), origin.y + (heightSpacing * y), origin.z + (lengthSpacing * z)));
-                    }
-                }
-            }
-
-            return testPoints;
-        }
-
         private float exfilSearchRetryDelay = 10;
         private Dictionary<SAINComponentClass, float> botExfilSearchRetryTime = new Dictionary<SAINComponentClass, float>();
 
@@ -392,9 +148,7 @@ namespace SAIN.Components.BotController
                 Logger.LogInfo($"Looking for Exfil for {bot.name}...");
             }
 
-            FindAllValidExfilsForBot(bot).ToEnumerable().Count();
-            
-            int validExfils = bot.Info.Profile.IsScav ? ValidScavExfils.Count : ValidExfils.Count;
+            int validExfils = GameWorldHandler.SAINGameWorld.ExtractFinder.CountValidExfilsForBot(bot);
             if (validExfils > 0)
             {
                 bool exfilAssigned = bot.Squad.BotInGroup ? TryAssignSquadExfil(bot) : TryAssignExfilForBot(bot);
@@ -434,27 +188,23 @@ namespace SAIN.Components.BotController
 
         public bool TryAssignExfilForBot(SAINComponentClass bot)
         {
-            if (bot?.Info?.Profile.IsScav == true)
-            {
-                bot.Memory.ExfilPoint = selectExfilForBot(bot, ValidScavExfils);
-            }
-            if (bot?.Info?.Profile.IsPMC == true)
-            {
-                bot.Memory.ExfilPoint = selectExfilForBot(bot, ValidExfils);
-            }
+            IDictionary<ExfiltrationPoint, Vector3> validExfils = GameWorldHandler.SAINGameWorld.ExtractFinder.GetValidExfilsForBot(bot);
+            bot.Memory.ExfilPoint = selectExfilForBot(bot, validExfils);
 
             return bot.Memory.ExfilPoint != null;
         }
 
         public static float MinDistanceToExtract { get; private set; } = 10f;
 
-        private T selectExfilForBot<T>(SAINComponentClass bot, IDictionary<T, Vector3> validExfils) where T: ExfiltrationPoint
+        private ExfiltrationPoint selectExfilForBot(SAINComponentClass bot, IDictionary<ExfiltrationPoint, Vector3> validExfils)
         {
             // Check each valid extract to ensure the bot can use it and that it isn't too close. If this method is called when a bot is near an extract, it might be because
             // it got stuck. 
-            IDictionary<T, Vector3> possibleExfils = validExfils
+            NavMeshPath path = new NavMeshPath();
+            IDictionary<ExfiltrationPoint, Vector3> possibleExfils = validExfils
                     .Where(x => CanUseExtract(x.Key))
                     .Where(x => Vector3.Distance(bot.Position, x.Value) > MinDistanceToExtract)
+                    .Where(x => NavMesh.CalculatePath(bot.Position, x.Value, -1, path) && (path.status == NavMeshPathStatus.PathComplete))
                     .ToDictionary(x => x.Key, x => x.Value);
 
             if (!possibleExfils.Any())
@@ -467,7 +217,7 @@ namespace SAIN.Components.BotController
                 return null;
             }
 
-            KeyValuePair<T, Vector3> selectedExfil = possibleExfils.Random();
+            KeyValuePair<ExfiltrationPoint, Vector3> selectedExfil = possibleExfils.Random();
             bot.Memory.ExfilPosition = selectedExfil.Value;
 
             if (SAINPlugin.DebugMode)

--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -9,11 +9,7 @@ using UnityEngine.AI;
 using SAIN.SAINComponent;
 using SAIN.Helpers;
 using System.Collections;
-using System.Reflection;
 using HarmonyLib;
-using Unity.Jobs;
-using Unity.Collections;
-using UnityEngine.UIElements;
 
 namespace SAIN.Components.BotController
 {

--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -145,34 +145,33 @@ namespace SAIN.Components.BotController
             }
 
             int validExfils = GameWorldHandler.SAINGameWorld.ExtractFinder.CountValidExfilsForBot(bot);
-            if (validExfils > 0)
-            {
-                bool exfilAssigned = bot.Squad.BotInGroup ? TryAssignSquadExfil(bot) : TryAssignExfilForBot(bot);
-            }
-            else
+            if (validExfils == 0)
             {
                 if (SAINPlugin.DebugMode)
                 {
                     Logger.LogInfo($"Could not select exfil for {bot.name}; no valid ones found");
                 }
+
+                ResetExfilSearchTime(bot);
+                return false;
             }
 
-            if (bot.Memory.ExfilPosition == null)
+            bool exfilAssigned = bot.Squad.BotInGroup ? TryAssignSquadExfil(bot) : TryAssignExfilForBot(bot);
+            if (!exfilAssigned)
             {
                 if (SAINPlugin.DebugMode)
                 {
-                    Logger.LogInfo($"{bot.BotOwner.name} Could Not find Exfil. Type: {bot.Info.WildSpawnType}");
+                    Logger.LogInfo($"{bot.name} could not find exfil. Bot spawn type: {bot.Info.WildSpawnType}");
                 }
 
                 ResetExfilSearchTime(bot);
-
                 return false;
             }
 
             return true;
         }
 
-        public bool IsBotAllowedToExfil(SAINComponentClass bot)
+        public static bool IsBotAllowedToExfil(SAINComponentClass bot)
         {
             if (!bot.Info.Profile.IsPMC && !bot.Info.Profile.IsScav)
             {

--- a/BotController/Classes/BotExtractManager.cs
+++ b/BotController/Classes/BotExtractManager.cs
@@ -227,7 +227,7 @@ namespace SAIN.Components.BotController
                     continue;
                 }
 
-                if (!bot.Mover.CanGoToPoint(collider.transform.position, out Vector3 Destination, true))
+                if (!bot.Mover.CanGoToPoint(collider.transform.position, out Vector3 Destination, true, 0.5f))
                 {
                     if (SAINPlugin.DebugMode)
                         Logger.LogWarning($"Could not find valid path to {ex.Settings.Name}");

--- a/BotController/SAINBotControllerComponent.cs
+++ b/BotController/SAINBotControllerComponent.cs
@@ -36,8 +36,7 @@ namespace SAIN.Components
         public Vector3 MainPlayerPosition { get; private set; }
         private bool ComponentAdded { get; set; }
         private float UpdatePositionTimer { get; set; }
-        private float CheckExtractTimer = 0f;
-
+        
         private void Awake()
         {
             GameWorld.OnDispose += Dispose;
@@ -79,20 +78,6 @@ namespace SAIN.Components
             //PathManager.Update();
             //AddNavObstacles();
             //UpdateObstacles();
-
-            if (CheckExtractTimer > Time.time)
-            {
-                return;
-            }
-
-            CheckExtractTimer = Time.time + 20f;
-
-            if (!BotExtractManager.IsFindingAllValidExfilsForAllBots)
-            {
-                // This should be done regularly because the method checks if bots can path to each extract. However, it needs to be done
-                // in a coroutine to minimize the performance impact
-                StartCoroutine(BotExtractManager.EnumerateAllValidExfilsForAllBots());
-            }
         }
 
         private void PlayerTalked(EPhraseTrigger phrase, ETagStatus mask, Player player)

--- a/Components/Extract/ExtractFinderComponent.cs
+++ b/Components/Extract/ExtractFinderComponent.cs
@@ -163,12 +163,25 @@ namespace SAIN.Components.Extract
 
         private IEnumerator FindAllExfils()
         {
-            IsFindingExtracts = true;
+            bool completedCoroutine = false;
+            try
+            {
+                IsFindingExtracts = true;
 
-            yield return UpdateValidExfils(ValidExfils, AllExfils);
-            yield return UpdateValidExfils(ValidScavExfils, AllScavExfils);
+                yield return UpdateValidExfils(ValidExfils, AllExfils);
+                yield return UpdateValidExfils(ValidScavExfils, AllScavExfils);
 
-            IsFindingExtracts = false;
+                completedCoroutine = true;
+            }
+            finally
+            {
+                IsFindingExtracts = false;
+
+                if (!completedCoroutine)
+                {
+                    Logger.LogError("An error occurred when searching for extracts.");
+                }
+            }
         }
 
         private IEnumerator UpdateValidExfils(IDictionary<ExfiltrationPoint, Vector3> validExfils, ExfiltrationPoint[] allExfils)

--- a/Components/Extract/ExtractFinderComponent.cs
+++ b/Components/Extract/ExtractFinderComponent.cs
@@ -23,7 +23,9 @@ namespace SAIN.Components.Extract
         private Dictionary<ExfiltrationPoint, Vector3> ValidExfils = new Dictionary<ExfiltrationPoint, Vector3>();
         private Dictionary<ExfiltrationPoint, Vector3> ValidScavExfils = new Dictionary<ExfiltrationPoint, Vector3>();
         private Dictionary<ExfiltrationPoint, ExtractPositionFinder> extractPositionFinders = new Dictionary<ExfiltrationPoint, ExtractPositionFinder>();
-        private float CheckExtractTimer = 0f;
+
+        private float CheckExtractDelay = 10f;
+        private float NextCheckExtractTime = 0f;
 
         public void Update()
         {
@@ -32,12 +34,12 @@ namespace SAIN.Components.Extract
                 return;
             }
 
-            if (CheckExtractTimer > Time.time)
+            if (NextCheckExtractTime > Time.time)
             {
                 return;
             }
 
-            CheckExtractTimer = Time.time + 20f;
+            NextCheckExtractTime = Time.time + CheckExtractDelay;
 
             if (!IsFindingExtracts)
             {
@@ -115,14 +117,18 @@ namespace SAIN.Components.Extract
                 }
 
                 ExtractPositionFinder finder = GetExtractPositionSearchJob(ex);
-                yield return finder.SearchForExfilPosition();
-
                 if (!finder.ValidPathFound)
                 {
+                    yield return finder.SearchForExfilPosition();
+                }
+                if (!finder.ValidPathFound)
+                {
+                    finder.CreateDebugSphere(Color.red);
                     continue;
                 }
 
                 validExfils.Add(ex, finder.ExtractPosition.Value);
+                finder.CreateDebugSphere(Color.green);
             }
         }
 

--- a/Components/Extract/ExtractFinderComponent.cs
+++ b/Components/Extract/ExtractFinderComponent.cs
@@ -1,0 +1,142 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.Interactive;
+using SAIN.SAINComponent;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Unity.Jobs;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace SAIN.Components.Extract
+{
+    public class ExtractFinderComponent : MonoBehaviour
+    {
+        public bool IsFindingExtracts { get; private set; } = false;
+
+        private ExfiltrationPoint[] AllExfils;
+        private ExfiltrationPoint[] AllScavExfils;
+        private Dictionary<ExfiltrationPoint, Vector3> ValidExfils = new Dictionary<ExfiltrationPoint, Vector3>();
+        private Dictionary<ExfiltrationPoint, Vector3> ValidScavExfils = new Dictionary<ExfiltrationPoint, Vector3>();
+        private Dictionary<ExfiltrationPoint, ExtractPositionFinder> extractPositionFinders = new Dictionary<ExfiltrationPoint, ExtractPositionFinder>();
+        private float CheckExtractTimer = 0f;
+
+        public void Update()
+        {
+            if (!GetExfilControl())
+            {
+                return;
+            }
+
+            if (CheckExtractTimer > Time.time)
+            {
+                return;
+            }
+
+            CheckExtractTimer = Time.time + 20f;
+
+            if (!IsFindingExtracts)
+            {
+                // This should be done regularly because the method checks if bots can path to each extract. However, it needs to be done
+                // in a coroutine to minimize the performance impact
+                StartCoroutine(FindAllExfils());
+            }
+        }
+
+        public void OnDisable()
+        {
+            StopAllCoroutines();
+        }
+
+        public int CountValidExfilsForBot(SAINComponentClass bot)
+        {
+            return GetValidExfilsForBot(bot).Count;
+        }
+
+        public IDictionary<ExfiltrationPoint, Vector3> GetValidExfilsForBot(SAINComponentClass bot)
+        {
+            return bot.Info.Profile.IsScav ? ValidScavExfils : ValidExfils;
+        }
+
+        private bool GetExfilControl()
+        {
+            if (Singleton<AbstractGame>.Instance?.GameTimer == null)
+            {
+                return false;
+            }
+
+            ExfiltrationControllerClass ExfilController = Singleton<GameWorld>.Instance.ExfiltrationController;
+            if (ExfilController == null)
+            {
+                return false;
+            }
+
+            AllExfils = ExfilController.ExfiltrationPoints;
+            if (SAINPlugin.DebugMode && AllExfils != null)
+            {
+                Logger.LogInfo($"Found {AllExfils?.Length} possible Exfil Points in this map.");
+            }
+
+            AllScavExfils = ExfilController.ScavExfiltrationPoints;
+            if (SAINPlugin.DebugMode && AllScavExfils != null)
+            {
+                Logger.LogInfo($"Found {AllScavExfils?.Length} possible Scav Exfil Points in this map.");
+            }
+
+            return true;
+        }
+
+        private IEnumerator FindAllExfils()
+        {
+            IsFindingExtracts = true;
+
+            yield return UpdateValidExfils(ValidExfils, AllExfils);
+            yield return UpdateValidExfils(ValidScavExfils, AllScavExfils);
+
+            IsFindingExtracts = false;
+        }
+
+        private IEnumerator UpdateValidExfils(IDictionary<ExfiltrationPoint, Vector3> validExfils, ExfiltrationPoint[] allExfils)
+        {
+            if (allExfils == null)
+            {
+                yield break;
+            }
+
+            foreach (var ex in allExfils)
+            {
+                if (validExfils.ContainsKey(ex))
+                {
+                    continue;
+                }
+
+                ExtractPositionFinder finder = GetExtractPositionSearchJob(ex);
+                yield return finder.SearchForExfilPosition();
+
+                if (!finder.ValidPathFound)
+                {
+                    continue;
+                }
+
+                validExfils.Add(ex, finder.ExtractPosition.Value);
+            }
+        }
+
+        private ExtractPositionFinder GetExtractPositionSearchJob(ExfiltrationPoint ex)
+        {
+            if (extractPositionFinders.ContainsKey(ex))
+            {
+                return extractPositionFinders[ex];
+            }
+
+            ExtractPositionFinder job = new ExtractPositionFinder(ex);
+            extractPositionFinders.Add(ex, job);
+
+            return job;
+        }
+    }
+}

--- a/Components/Extract/ExtractFinderComponent.cs
+++ b/Components/Extract/ExtractFinderComponent.cs
@@ -59,7 +59,7 @@ namespace SAIN.Components.Extract
 
         public void OnGUI()
         {
-            if (!DebugGizmos.DrawGizmos)
+            if (!SAINPlugin.DebugMode || !DebugGizmos.DrawGizmos)
             {
                 return;
             }

--- a/Components/Extract/ExtractPositionFinder.cs
+++ b/Components/Extract/ExtractPositionFinder.cs
@@ -25,17 +25,32 @@ namespace SAIN.Components.Extract
         
         private static FieldInfo colliderField = AccessTools.Field(typeof(ExfiltrationPoint), "_collider");
         
+        // Parameters to determine the range of how dense the 3D mesh in the extract collider will be. Denser meshes have a higher
+        // chance of finding valid NavMesh points, but performance will be worse. 
+        private static float initialColliderTestPointDensityFactor = 1f;
+        private static float minColliderTestPointDensityFactor = 0.1f;
+        private static int maxColliderTestPoints = 25;
+
+        // Parameters to determine how large the radii will be for each point in the 3D mesh. The radii will never be allowed to
+        // exceed the bounds of the mesh, but we can limit the initial radii to improve performance.
+        private static float defaultExtractNavMeshSearchRadius = 3f;
+        private static float maxExtractNavMeshSearchRadius = 5f;
+
+        // After the 3D mesh is generated, the search radius will be increased by this amount to search for the NavMesh.
         // If this is smaller than ~0.75m, no NavMesh points can be found for the Labs Vent extract. However, the larger it gets,
         // the more likely it is that a NavMesh point will be selected that's outside of the extract collider. 
         private static float finalExtractNavMeshSearchRadiusAddition = 0.75f;
 
-        private static float initialNavMeshTestPointDensityFactor = 1f;
-        private static float minNavMeshTestPointDensityFactor = 0.1f;
-        private static float defaultExtractNavMeshSearchRadius = 3f;
-        private static float maxExtractNavMeshSearchRadius = 5f;
+        // When searching for endpoints from which pathing will be testing to the extract, endpoints with different elevation from
+        // the extract point need to be deprioritized. Otherwise, it will be more likely to select points that are on different floors in
+        // a building, which are much less likely to result in complete paths being calculated. To address this, an additional factor
+        // of this value multiplied by the difference in elevation (in meters) is added to the distance between the points.
         private static float pathEndpointHeightDeprioritizationFactor = 2;
+
+        // The minimum distance between each endpoint used to check if a complete path exists to the extract
         private static float minDistanceBetweenPathEndpoints = 75;
-        private static int maxColliderTestPoints = 25;
+
+        // The number of endpoints to use for checking if a complete path exists to the extract
         private static int maxPathEndpoints = 2;
 
         private ExfiltrationPoint ex = null;
@@ -59,84 +74,75 @@ namespace SAIN.Components.Extract
 
             if (ex == null)
             {
-                if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Exfil is null in list!");
+                Logger.LogError($"Cannot find a position for a null exfil point");
 
                 yield break;
             }
 
+            // Select points on the NavMesh within the extract collider that will be used to check if a complete path exists
             FindExtractPositionsOnNavMesh();
             if (!navMeshTestPoints.Any())
             {
-                //if (SAINPlugin.DebugMode)
+                if (SAINPlugin.DebugMode)
                     Logger.LogWarning($"Cannot find any NavMesh positions for {ex.Settings.Name}");
 
                 yield break;
             }
 
+            // Select the next point from the mesh generated above
             ExtractPosition = navMeshTestPoints.Pop();
-            //if (SAINPlugin.DebugMode)
+            if (SAINPlugin.DebugMode)
                 Logger.LogInfo($"Testing point {ExtractPosition} for {ex.Settings.Name}. {navMeshTestPoints.Count} test points remaining.");
 
+            // Choose endpoints from which pathing to the extract will be tested
             FindPathEndPoints(ExtractPosition.Value);
             if (pathEndpoints.Count == 0)
             {
-                //if (SAINPlugin.DebugMode)
+                if (SAINPlugin.DebugMode)
                     Logger.LogWarning($"Could not find any path endpoints near {ex.Settings.Name}");
 
                 yield break;
             }
 
+            // Check if a complete path can be calculated between the extract position and each endpoint selected above
             foreach (Vector3 pathEndPoint in pathEndpoints)
             {
-                if (DoesCompletePathExistToExtractPoint(pathEndPoint))
+                if (NavMeshHelpers.DoesCompletePathExist(pathEndPoint, ExtractPosition.Value))
                 {
                     ValidPathFound = true;
 
-                    //if (SAINPlugin.DebugMode)
-                    Logger.LogInfo($"Found complete path to {ex.Settings.Name}");
+                    if (SAINPlugin.DebugMode)
+                        Logger.LogInfo($"Found complete path to {ex.Settings.Name}");
 
                     yield break;
                 }
 
+                if (SAINPlugin.DebugMode)
+                {
+                    float distanceBetweenPoints = Vector3.Distance(ExtractPosition.Value, pathEndPoint);
+                    Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name} from {pathEndPoint} ({distanceBetweenPoints}m away).");
+                }
+
+                // Wait one frame to reduce the performance impact
                 yield return null;
             }
 
-            //if (SAINPlugin.DebugMode)
+            if (SAINPlugin.DebugMode)
                 Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name}");
-        }
-
-        private bool DoesCompletePathExistToExtractPoint(Vector3 startingPoint)
-        {
-            if (!ExtractPosition.HasValue)
-            {
-                throw new InvalidOperationException("An extract position must be set before a path can be checked to it");
-            }
-
-            if (!NavMeshHelpers.DoesCompletePathExist(startingPoint, ExtractPosition.Value))
-            {
-                //if (SAINPlugin.DebugMode)
-                {
-                    float distanceBetweenPoints = Vector3.Distance(ex.transform.position, startingPoint);
-
-                    Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name} from {startingPoint} ({distanceBetweenPoints}m away).");
-                }
-
-                return false;
-            }
-
-            return true;
         }
 
         private float GetColliderTestPointSearchRadius(BoxCollider collider)
         {
+            // The search radius should be no larger than the extents of the collider (up to the maximum allowed radius)
             float searchRadius = Math.Min(Math.Min(collider.size.x, collider.size.y), collider.size.z) / 2;
             searchRadius = Math.Min(searchRadius, maxExtractNavMeshSearchRadius);
+
+            // Failsafe for a junk extract collider
             if (searchRadius == 0)
             {
                 searchRadius = defaultExtractNavMeshSearchRadius;
 
-                //if (SAINPlugin.DebugMode)
+                if (SAINPlugin.DebugMode)
                     Logger.LogWarning($"Collider size of {ex.Settings.Name} is (0, 0, 0). Using {searchRadius}m to check accessibility.");
             }
 
@@ -145,11 +151,13 @@ namespace SAIN.Components.Extract
 
         private void FindExtractPositionsOnNavMesh()
         {
+            // If there are still remaining points to test, use them first
             if (navMeshTestPoints.Any())
             {
                 return;
             }
 
+            // If NavMesh points have already been seelected in the extract collider, use them
             if (sortedNavMeshPoints.Any())
             {
                 CreateNavMeshTestPointStack();
@@ -159,28 +167,29 @@ namespace SAIN.Components.Extract
             BoxCollider collider = (BoxCollider)colliderField.GetValue(ex);
             if (collider == null)
             {
-                //if (SAINPlugin.DebugMode)
-                Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
+                if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
 
                 return;
             }
 
+            // Generate the 3D mesh of test points and filter them to only include points that intersect with the NavMesh
             float searchRadius = GetColliderTestPointSearchRadius(collider);
             IEnumerable<Vector3> colliderTestPoints = GetColliderTestPoints(collider, searchRadius);
-            IEnumerable<Vector3> navMeshPoints = GetColliderTestPointsOnNavMesh(colliderTestPoints, searchRadius + finalExtractNavMeshSearchRadiusAddition);
-            List<Vector3> navMeshPointsToSort = navMeshPoints.ToArray().ToList();
-
+            IList<Vector3> navMeshPoints = GetColliderTestPointsOnNavMesh(colliderTestPoints, searchRadius + finalExtractNavMeshSearchRadiusAddition);
+            
+            // Sort the filtered points to first test the one closest to the center of the collider and then its extremities
             Vector3 referencePoint = ex.transform.position;
             bool chooseFirst = true;
-            while (navMeshPointsToSort.Count > 0)
+            while (navMeshPoints.Count > 0)
             {
-                IEnumerable<Vector3> tmpSortedNavMeshPoints = navMeshPointsToSort.OrderBy(x => Vector3.Distance(x, referencePoint));
+                IEnumerable<Vector3> tmpSortedNavMeshPoints = navMeshPoints.OrderBy(x => Vector3.Distance(x, referencePoint));
 
                 referencePoint = chooseFirst ? tmpSortedNavMeshPoints.First() : tmpSortedNavMeshPoints.Last();
-                chooseFirst = !chooseFirst;
+                chooseFirst = false;
 
                 sortedNavMeshPoints.Add(referencePoint);
-                navMeshPointsToSort.Remove(referencePoint);
+                navMeshPoints.Remove(referencePoint);
             }
 
             sortedNavMeshPoints.Reverse();
@@ -194,22 +203,25 @@ namespace SAIN.Components.Extract
                 navMeshTestPoints.Push(testPoint);
             }
 
-            //if (SAINPlugin.DebugMode)
+            if (SAINPlugin.DebugMode)
                 Logger.LogInfo($"Found {navMeshTestPoints.Count} extract postions for {ex.Settings.Name}");
         }
 
         private IEnumerable<Vector3> GetColliderTestPoints(BoxCollider collider, float searchRadius)
         {
-            float navNeshTestPointDensityFactor = initialNavMeshTestPointDensityFactor;
+            // Adjust the 3D mesh density to limit the number of points in it, but do not allow the density to drop below a certain point
+            float navNeshTestPointDensityFactor = initialColliderTestPointDensityFactor;
             IEnumerable<Vector3> colliderTestPoints = Enumerable.Repeat(Vector3.positiveInfinity, maxColliderTestPoints + 1);
             int lastPointCount = colliderTestPoints.Count();
-            while ((lastPointCount > maxColliderTestPoints) && (navNeshTestPointDensityFactor >= minNavMeshTestPointDensityFactor))
+            while ((lastPointCount > maxColliderTestPoints) && (navNeshTestPointDensityFactor >= minColliderTestPointDensityFactor))
             {
                 colliderTestPoints = collider.GetNavMeshTestPoints(searchRadius, navNeshTestPointDensityFactor);
+
+                // If the number of points is the same as the previous iteration, give up
                 if (colliderTestPoints.Count() == lastPointCount)
                 {
-                    //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not minimize collider test point count for {ex.Settings.Name}");
+                    if (SAINPlugin.DebugMode)
+                        Logger.LogWarning($"Could not minimize collider test point count for {ex.Settings.Name}");
 
                     break;
                 }
@@ -223,21 +235,24 @@ namespace SAIN.Components.Extract
             {
                 colliderTestPoints = Enumerable.Repeat(collider.transform.position, 1);
 
-                //if (SAINPlugin.DebugMode)
-                Logger.LogWarning($"Could not create test points. Using collider position instead");
+                if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not create test points. Using collider position instead");
             }
-
-            //if (SAINPlugin.DebugMode)
+            else
             {
-                Logger.LogInfo($"Generated {colliderTestPoints.Count()} collider test points using a density factor of {Math.Round(navNeshTestPointDensityFactor, 3)} and a search radius of {searchRadius}m");
-                Logger.LogInfo($"Extract collider: center={collider.transform.position}, size={collider.size}.");
+                if (SAINPlugin.DebugMode)
+                {
+                    Logger.LogInfo($"Generated {colliderTestPoints.Count()} collider test points using a density factor of {Math.Round(navNeshTestPointDensityFactor, 3)} and a search radius of {searchRadius}m");
+                    Logger.LogInfo($"Extract collider: center={collider.transform.position}, size={collider.size}.");
+                }
             }
 
             return colliderTestPoints;
         }
 
-        private IEnumerable<Vector3> GetColliderTestPointsOnNavMesh(IEnumerable<Vector3> colliderTestPoints, float searchRadius)
+        private IList<Vector3> GetColliderTestPointsOnNavMesh(IEnumerable<Vector3> colliderTestPoints, float searchRadius)
         {
+            // For each point in the 3D mesh, try to find a point on the NavMesh within a certain radius
             List<Vector3> navMeshPoints = new List<Vector3>();
             foreach (Vector3 testPoint in colliderTestPoints)
             {
@@ -247,6 +262,7 @@ namespace SAIN.Components.Extract
                     continue;
                 }
 
+                // Do not allow duplicate point to be added, which is possible depending on the mesh density
                 if (navMeshPoints.Any(x => x == navMeshPoint))
                 {
                     continue;
@@ -255,15 +271,10 @@ namespace SAIN.Components.Extract
                 navMeshPoints.Add(navMeshPoint.Value);
             }
 
-            if (!navMeshPoints.Any())
+            if (SAINPlugin.DebugMode && !navMeshPoints.Any())
             {
-                //if (SAINPlugin.DebugMode)
-                {
-                    Logger.LogWarning($"Could not find any NavMesh points for {ex.Settings.Name} from {colliderTestPoints.Count()} test points using radius {searchRadius}m");
-                    Logger.LogWarning($"Test points: {string.Join(",", colliderTestPoints)}");
-                }
-
-                return Enumerable.Empty<Vector3>();
+                Logger.LogWarning($"Could not find any NavMesh points for {ex.Settings.Name} from {colliderTestPoints.Count()} test points using radius {searchRadius}m");
+                Logger.LogWarning($"Test points: {string.Join(",", colliderTestPoints)}");
             }
 
             return navMeshPoints;
@@ -271,20 +282,24 @@ namespace SAIN.Components.Extract
 
         private void FindPathEndPoints(Vector3 testPoint)
         {
+            // If endpoints have already been selected for the extract, use them
             if (pathEndpoints.Count > 0)
             {
                 return;
             }
 
-            IEnumerable<Vector3> navMeshPoints = GetAllSpawnPointPositionsOnNavMesh();
+            IEnumerable<Vector3> navMeshPoints = GameWorldHandler.SAINGameWorld.GetAllSpawnPointPositionsOnNavMesh();
             if (!navMeshPoints.Any())
             {
                 return;
             }
 
+            // Create a dictionary of the distance between each spawn point and the extract test point, but deprioritize points with
+            // much different elevation
             Dictionary<Vector3, float> navMeshPointDistances = navMeshPoints
                 .ToDictionary(x => x, x => Vector3.Distance(x, testPoint) + (Math.Abs(x.y - testPoint.y) * pathEndpointHeightDeprioritizationFactor));
 
+            // Select the desired number of endpoints ensuring they are not too close together
             for (int i = 0; i < maxPathEndpoints; i++)
             {
                 IEnumerable<Vector3>  sortedNavMeshPoints = navMeshPoints
@@ -298,21 +313,6 @@ namespace SAIN.Components.Extract
 
                 pathEndpoints.Add(sortedNavMeshPoints.First());
             }
-        }
-
-        private static IEnumerable<Vector3> GetAllSpawnPointPositionsOnNavMesh()
-        {
-            List<Vector3> spawnPointPositions = new List<Vector3>();
-            foreach (SpawnPointMarker spawnPointMarker in GameWorldHandler.SAINGameWorld.SpawnPointMarkers)
-            {
-                Vector3? spawnPointPosition = NavMeshHelpers.GetNearbyNavMeshPoint(spawnPointMarker.Position, 2);
-                if (spawnPointPosition.HasValue && !spawnPointPositions.Contains(spawnPointPosition.Value))
-                {
-                    spawnPointPositions.Add(spawnPointPosition.Value);
-                }
-            }
-
-            return spawnPointPositions;
         }
     }
 }

--- a/Components/Extract/ExtractPositionFinder.cs
+++ b/Components/Extract/ExtractPositionFinder.cs
@@ -22,19 +22,28 @@ namespace SAIN.Components.Extract
     {
         public bool ValidPathFound { get; private set; } = false;
         public Vector3? ExtractPosition { get; private set; } = null;
-        public Vector3? NearestSpawnPosition { get; private set; } = null;
-        public float NavMeshSearchRadius { get; private set; } = 0;
-        public Stack<Vector3> NavMeshTestPoints { get; private set; } = new Stack<Vector3>();
         
         private static FieldInfo colliderField = AccessTools.Field(typeof(ExfiltrationPoint), "_collider");
-        private static float defaultExtractNavMeshSearchRadius = 3f;
-        private static float maxExtractNavMeshSearchRadius = 3f;
-
+        
         // If this is smaller than ~0.75m, no NavMesh points can be found for the Labs Vent extract. However, the larger it gets,
         // the more likely it is that a NavMesh point will be selected that's outside of the extract collider. 
         private static float finalExtractNavMeshSearchRadiusAddition = 0.75f;
 
+        private static float initialNavMeshTestPointDensityFactor = 1f;
+        private static float minNavMeshTestPointDensityFactor = 0.1f;
+        private static float defaultExtractNavMeshSearchRadius = 3f;
+        private static float maxExtractNavMeshSearchRadius = 5f;
+        private static float pathEndpointHeightDeprioritizationFactor = 2;
+        private static float minDistanceBetweenPathEndpoints = 75;
+        private static int maxColliderTestPoints = 25;
+        private static int maxPathEndpoints = 2;
+
         private ExfiltrationPoint ex = null;
+        private readonly List<Vector3> pathEndpoints = new List<Vector3>();
+        private readonly List<Vector3> sortedNavMeshPoints = new List<Vector3>();
+        private readonly Stack<Vector3> navMeshTestPoints = new Stack<Vector3>();
+        
+        public IReadOnlyCollection<Vector3> PathEndpoints => pathEndpoints.AsReadOnly();
 
         public ExtractPositionFinder(ExfiltrationPoint _ex)
         {
@@ -56,7 +65,8 @@ namespace SAIN.Components.Extract
                 yield break;
             }
 
-            if (!TryFindExtractPositionsOnNavMesh())
+            FindExtractPositionsOnNavMesh();
+            if (!navMeshTestPoints.Any())
             {
                 //if (SAINPlugin.DebugMode)
                     Logger.LogWarning($"Cannot find any NavMesh positions for {ex.Settings.Name}");
@@ -64,47 +74,52 @@ namespace SAIN.Components.Extract
                 yield break;
             }
 
-            ExtractPosition = NavMeshTestPoints.Pop();
+            ExtractPosition = navMeshTestPoints.Pop();
             //if (SAINPlugin.DebugMode)
-                Logger.LogInfo($"Testing point {ExtractPosition} for {ex.Settings.Name}. {NavMeshTestPoints.Count} test points remaining.");
+                Logger.LogInfo($"Testing point {ExtractPosition} for {ex.Settings.Name}. {navMeshTestPoints.Count} test points remaining.");
 
-            FindNearestSpawnPointPosition(ExtractPosition.Value);
-            if (NearestSpawnPosition == null)
+            FindPathEndPoints(ExtractPosition.Value);
+            if (pathEndpoints.Count == 0)
             {
                 //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not find a spawn position near {ex.Settings.Name}");
+                    Logger.LogWarning($"Could not find any path endpoints near {ex.Settings.Name}");
 
                 yield break;
             }
 
-            if (DoesCompletePathExist(NearestSpawnPosition.Value))
+            foreach (Vector3 pathEndPoint in pathEndpoints)
             {
-                ValidPathFound = true;
+                if (DoesCompletePathExistToExtractPoint(pathEndPoint))
+                {
+                    ValidPathFound = true;
 
-                //if (SAINPlugin.DebugMode)
+                    //if (SAINPlugin.DebugMode)
                     Logger.LogInfo($"Found complete path to {ex.Settings.Name}");
 
-                yield break;
+                    yield break;
+                }
+
+                yield return null;
             }
 
             //if (SAINPlugin.DebugMode)
                 Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name}");
         }
 
-        private bool DoesCompletePathExist(Vector3 point)
+        private bool DoesCompletePathExistToExtractPoint(Vector3 startingPoint)
         {
             if (!ExtractPosition.HasValue)
             {
                 throw new InvalidOperationException("An extract position must be set before a path can be checked to it");
             }
 
-            if (!NavMeshHelpers.DoesCompletePathExist(point, ExtractPosition.Value))
+            if (!NavMeshHelpers.DoesCompletePathExist(startingPoint, ExtractPosition.Value))
             {
                 //if (SAINPlugin.DebugMode)
                 {
-                    float distanceBetweenPoints = Vector3.Distance(ex.transform.position, point);
+                    float distanceBetweenPoints = Vector3.Distance(ex.transform.position, startingPoint);
 
-                    Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name} from {point} ({distanceBetweenPoints}m away).");
+                    Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name} from {startingPoint} ({distanceBetweenPoints}m away).");
                 }
 
                 return false;
@@ -113,47 +128,120 @@ namespace SAIN.Components.Extract
             return true;
         }
 
-        private bool TryFindExtractPositionsOnNavMesh()
+        private float GetColliderTestPointSearchRadius(BoxCollider collider)
         {
-            if (NavMeshTestPoints.Any())
+            float searchRadius = Math.Min(Math.Min(collider.size.x, collider.size.y), collider.size.z) / 2;
+            searchRadius = Math.Min(searchRadius, maxExtractNavMeshSearchRadius);
+            if (searchRadius == 0)
             {
-                return true;
+                searchRadius = defaultExtractNavMeshSearchRadius;
+
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Collider size of {ex.Settings.Name} is (0, 0, 0). Using {searchRadius}m to check accessibility.");
+            }
+
+            return searchRadius;
+        }
+
+        private void FindExtractPositionsOnNavMesh()
+        {
+            if (navMeshTestPoints.Any())
+            {
+                return;
+            }
+
+            if (sortedNavMeshPoints.Any())
+            {
+                CreateNavMeshTestPointStack();
+                return;
             }
 
             BoxCollider collider = (BoxCollider)colliderField.GetValue(ex);
             if (collider == null)
             {
                 //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
+                Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
 
-                return false;
+                return;
             }
 
-            NavMeshSearchRadius = Math.Min(Math.Min(collider.size.x, collider.size.y), collider.size.z) / 2;
-            NavMeshSearchRadius = Math.Min(NavMeshSearchRadius, maxExtractNavMeshSearchRadius);
-            if (NavMeshSearchRadius == 0)
+            float searchRadius = GetColliderTestPointSearchRadius(collider);
+            IEnumerable<Vector3> colliderTestPoints = GetColliderTestPoints(collider, searchRadius);
+            IEnumerable<Vector3> navMeshPoints = GetColliderTestPointsOnNavMesh(colliderTestPoints, searchRadius + finalExtractNavMeshSearchRadiusAddition);
+            List<Vector3> navMeshPointsToSort = navMeshPoints.ToArray().ToList();
+
+            Vector3 referencePoint = ex.transform.position;
+            bool chooseFirst = true;
+            while (navMeshPointsToSort.Count > 0)
             {
-                NavMeshSearchRadius = defaultExtractNavMeshSearchRadius;
+                IEnumerable<Vector3> tmpSortedNavMeshPoints = navMeshPointsToSort.OrderBy(x => Vector3.Distance(x, referencePoint));
 
-                //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Collider size of {ex.Settings.Name} is (0, 0, 0). Using {NavMeshSearchRadius}m to check accessibility.");
+                referencePoint = chooseFirst ? tmpSortedNavMeshPoints.First() : tmpSortedNavMeshPoints.Last();
+                chooseFirst = !chooseFirst;
+
+                sortedNavMeshPoints.Add(referencePoint);
+                navMeshPointsToSort.Remove(referencePoint);
             }
 
-            IEnumerable<Vector3> colliderTestPoints = collider.GetNavMeshTestPoints(NavMeshSearchRadius, 2);
+            sortedNavMeshPoints.Reverse();
+            CreateNavMeshTestPointStack();
+        }
+
+        private void CreateNavMeshTestPointStack()
+        {
+            foreach (Vector3 testPoint in sortedNavMeshPoints)
+            {
+                navMeshTestPoints.Push(testPoint);
+            }
+
+            //if (SAINPlugin.DebugMode)
+                Logger.LogInfo($"Found {navMeshTestPoints.Count} extract postions for {ex.Settings.Name}");
+        }
+
+        private IEnumerable<Vector3> GetColliderTestPoints(BoxCollider collider, float searchRadius)
+        {
+            float navNeshTestPointDensityFactor = initialNavMeshTestPointDensityFactor;
+            IEnumerable<Vector3> colliderTestPoints = Enumerable.Repeat(Vector3.positiveInfinity, maxColliderTestPoints + 1);
+            int lastPointCount = colliderTestPoints.Count();
+            while ((lastPointCount > maxColliderTestPoints) && (navNeshTestPointDensityFactor >= minNavMeshTestPointDensityFactor))
+            {
+                colliderTestPoints = collider.GetNavMeshTestPoints(searchRadius, navNeshTestPointDensityFactor);
+                if (colliderTestPoints.Count() == lastPointCount)
+                {
+                    //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not minimize collider test point count for {ex.Settings.Name}");
+
+                    break;
+                }
+
+                lastPointCount = colliderTestPoints.Count();
+                navNeshTestPointDensityFactor /= 2;
+            }
+            navNeshTestPointDensityFactor *= 2;
+
             if (!colliderTestPoints.Any())
             {
                 colliderTestPoints = Enumerable.Repeat(collider.transform.position, 1);
 
                 //if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Could not create test points. Using collider position instead");
+                Logger.LogWarning($"Could not create test points. Using collider position instead");
             }
 
-            NavMeshSearchRadius += finalExtractNavMeshSearchRadiusAddition;
+            //if (SAINPlugin.DebugMode)
+            {
+                Logger.LogInfo($"Generated {colliderTestPoints.Count()} collider test points using a density factor of {Math.Round(navNeshTestPointDensityFactor, 3)} and a search radius of {searchRadius}m");
+                Logger.LogInfo($"Extract collider: center={collider.transform.position}, size={collider.size}.");
+            }
 
+            return colliderTestPoints;
+        }
+
+        private IEnumerable<Vector3> GetColliderTestPointsOnNavMesh(IEnumerable<Vector3> colliderTestPoints, float searchRadius)
+        {
             List<Vector3> navMeshPoints = new List<Vector3>();
             foreach (Vector3 testPoint in colliderTestPoints)
             {
-                Vector3? navMeshPoint = GetNearbyNavMeshPoint(testPoint, NavMeshSearchRadius);
+                Vector3? navMeshPoint = NavMeshHelpers.GetNearbyNavMeshPoint(testPoint, searchRadius);
                 if (navMeshPoint == null)
                 {
                     continue;
@@ -171,78 +259,60 @@ namespace SAIN.Components.Extract
             {
                 //if (SAINPlugin.DebugMode)
                 {
-                    Logger.LogWarning($"Could not find any NavMesh points for {ex.Settings.Name} from {colliderTestPoints.Count()} test points using radius {NavMeshSearchRadius}m");
-                    Logger.LogWarning($"Extract collider: center={collider.transform.position}, size={collider.size}.");
+                    Logger.LogWarning($"Could not find any NavMesh points for {ex.Settings.Name} from {colliderTestPoints.Count()} test points using radius {searchRadius}m");
                     Logger.LogWarning($"Test points: {string.Join(",", colliderTestPoints)}");
                 }
 
-                return false;
+                return Enumerable.Empty<Vector3>();
             }
 
-            List<Vector3> navMeshPointsToSort = navMeshPoints.ToArray().ToList();
-            List<Vector3> sortedNavMeshPoints = new List<Vector3>();
-            Vector3 referencePoint = ex.transform.position;
-            bool chooseFirst = true;
-            while (navMeshPointsToSort.Count > 0)
-            {
-                IEnumerable<Vector3> tmpSortedNavMeshPoints = navMeshPointsToSort.OrderBy(x => Vector3.Distance(x, referencePoint));
-
-                referencePoint = chooseFirst ? tmpSortedNavMeshPoints.First() : tmpSortedNavMeshPoints.Last();
-                chooseFirst = !chooseFirst;
-
-                sortedNavMeshPoints.Add(referencePoint);
-                navMeshPointsToSort.Remove(referencePoint);
-            }
-
-            sortedNavMeshPoints.Reverse();
-            foreach (Vector3 testPoint in sortedNavMeshPoints)
-            {
-                NavMeshTestPoints.Push(testPoint);
-            }
-
-            //if (SAINPlugin.DebugMode)
-                Logger.LogInfo($"Found {NavMeshTestPoints.Count} extract postions for {ex.Settings.Name} using search radius {NavMeshSearchRadius}m");
-
-            return true;
+            return navMeshPoints;
         }
 
-        private static Vector3? GetNearbyNavMeshPoint(Vector3 testPoint, float radius)
+        private void FindPathEndPoints(Vector3 testPoint)
         {
-            if (NavMesh.SamplePosition(testPoint, out var hit, radius, -1))
+            if (pathEndpoints.Count > 0)
             {
-                return hit.position;
+                return;
             }
 
-            return null;
-        }
-
-        private Vector3? FindNearestSpawnPointPosition(Vector3 testPoint)
-        {
-            if (NearestSpawnPosition != null)
+            IEnumerable<Vector3> navMeshPoints = GetAllSpawnPointPositionsOnNavMesh();
+            if (!navMeshPoints.Any())
             {
-                return NearestSpawnPosition;
+                return;
             }
 
-            List<Vector3> navMeshPoints = new List<Vector3>();
-            foreach(SpawnPointMarker spawnPointMarker in GameWorldHandler.SAINGameWorld.SpawnPointMarkers)
+            Dictionary<Vector3, float> navMeshPointDistances = navMeshPoints
+                .ToDictionary(x => x, x => Vector3.Distance(x, testPoint) + (Math.Abs(x.y - testPoint.y) * pathEndpointHeightDeprioritizationFactor));
+
+            for (int i = 0; i < maxPathEndpoints; i++)
             {
-                Vector3? navMeshPoint = GetNearbyNavMeshPoint(spawnPointMarker.Position, 2);
-                if (navMeshPoint.HasValue)
+                IEnumerable<Vector3>  sortedNavMeshPoints = navMeshPoints
+                    .Where(x => pathEndpoints.All(y => Vector3.Distance(x, y) > minDistanceBetweenPathEndpoints))
+                    .OrderBy(x => navMeshPointDistances[x]);
+
+                if (!sortedNavMeshPoints.Any())
                 {
-                    navMeshPoints.Add(navMeshPoint.Value);
+                    break;
+                }
+
+                pathEndpoints.Add(sortedNavMeshPoints.First());
+            }
+        }
+
+        private static IEnumerable<Vector3> GetAllSpawnPointPositionsOnNavMesh()
+        {
+            List<Vector3> spawnPointPositions = new List<Vector3>();
+            foreach (SpawnPointMarker spawnPointMarker in GameWorldHandler.SAINGameWorld.SpawnPointMarkers)
+            {
+                Vector3? spawnPointPosition = NavMeshHelpers.GetNearbyNavMeshPoint(spawnPointMarker.Position, 2);
+                if (spawnPointPosition.HasValue && !spawnPointPositions.Contains(spawnPointPosition.Value))
+                {
+                    spawnPointPositions.Add(spawnPointPosition.Value);
                 }
             }
 
-            float heightDeprioritizationFactor = 5;
-            IEnumerable<Vector3> sortedNavMeshPoints = navMeshPoints.OrderBy(x => Vector3.Distance(x, testPoint) + (Math.Abs(x.y - testPoint.y) * heightDeprioritizationFactor));
-            if (!sortedNavMeshPoints.Any())
-            {
-                return null;
-            }
-
-            NearestSpawnPosition = sortedNavMeshPoints.First();
-
-            return NearestSpawnPosition;
+            return spawnPointPositions;
         }
     }
 }

--- a/Components/Extract/ExtractPositionFinder.cs
+++ b/Components/Extract/ExtractPositionFinder.cs
@@ -1,0 +1,180 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.Game.Spawning;
+using EFT.Interactive;
+using EFT.UI;
+using HarmonyLib;
+using SAIN.Helpers;
+using SAIN.SAINComponent;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace SAIN.Components.Extract
+{
+    public class ExtractPositionFinder
+    {
+        public bool ValidPathFound { get; private set; } = false;
+        public Vector3? ExtractPosition { get; private set; } = null;
+        public Vector3? NearestSpawnPosition { get; private set; } = null;
+        public float NavMeshSearchRadius { get; private set; } = 0;
+        public Vector3[] NavMeshTestPoints { get; private set; } = new Vector3[0];
+
+        private static FieldInfo colliderField = AccessTools.Field(typeof(ExfiltrationPoint), "_collider");
+        private static float defaultExtractNavMeshSearchRadius = 3f;
+
+        private ExfiltrationPoint ex;
+
+        public ExtractPositionFinder(ExfiltrationPoint _ex)
+        {
+            ex = _ex;
+        }
+
+        public IEnumerator SearchForExfilPosition()
+        {
+            if (ex == null)
+            {
+                if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Exfil is null in list!");
+
+                yield break;
+            }
+
+            FindExtractPosition();
+            if (ExtractPosition == null)
+            {
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Cannot find NavMesh position for {ex.Settings.Name}");
+
+                yield break;
+            }
+
+            FindNearestSpawnPointPosition(ExtractPosition.Value);
+            if (NearestSpawnPosition == null)
+            {
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not find a spawn position near {ex.Settings.Name}");
+
+                yield break;
+            }
+
+            if (!NavMeshHelpers.DoesCompletePathExist(NearestSpawnPosition.Value, ExtractPosition.Value))
+            {
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not find a complete path to {ex.Settings.Name}");
+
+                yield break;
+            }
+
+            ValidPathFound = true;
+
+            //if (SAINPlugin.DebugMode)
+                Logger.LogInfo($"Found complete path to {ex.Settings.Name}");
+        }
+
+        private Vector3? FindExtractPosition()
+        {
+            if (ExtractPosition != null)
+            {
+                return ExtractPosition;
+            }
+
+            BoxCollider collider = (BoxCollider)colliderField.GetValue(ex);
+            if (collider == null)
+            {
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not find collider for {ex.Settings.Name}");
+
+                return null;
+            }
+
+            NavMeshSearchRadius = Math.Min(Math.Min(collider.size.x, collider.size.y), collider.size.z) / 2;
+            if (NavMeshSearchRadius == 0)
+            {
+                NavMeshSearchRadius = defaultExtractNavMeshSearchRadius;
+
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Collider size of {ex.Settings.Name} is (0, 0, 0). Using {NavMeshSearchRadius}m to check accessibility.");
+            }
+
+            IEnumerable<Vector3> colliderTestPoints = collider.GetNavMeshTestPoints(NavMeshSearchRadius, 2);
+            if (!colliderTestPoints.Any())
+            {
+                colliderTestPoints = Enumerable.Repeat(collider.transform.position, 1);
+
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not create test points. Using collider position instead");
+            }
+
+            NavMeshSearchRadius += 0.5f;
+
+            List<Vector3> navMeshPoints = new List<Vector3>();
+            foreach (Vector3 testPoint in colliderTestPoints)
+            {
+                Vector3? navMeshPoint = GetNearbyNavMeshPoint(testPoint, NavMeshSearchRadius);
+                if (navMeshPoint == null)
+                {
+                    continue;
+                }
+
+                navMeshPoints.Add(navMeshPoint.Value);
+            }
+
+            NavMeshTestPoints = navMeshPoints.ToArray();
+
+            IEnumerable<Vector3> sortedNavMeshPoints = navMeshPoints.OrderBy(x => Vector3.Distance(x, ex.transform.position));
+            if (!sortedNavMeshPoints.Any())
+            {
+                //if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Could not find any NavMesh points for {ex.Settings.Name} from {colliderTestPoints.Count()} test points using radius {NavMeshSearchRadius}m");
+
+                return null;
+            }
+
+            ExtractPosition = sortedNavMeshPoints.First();
+
+            //if (SAINPlugin.DebugMode)
+                Logger.LogInfo($"Found extract postion {ExtractPosition} for {ex.Settings.Name} using search radius {NavMeshSearchRadius}m");
+
+            return ExtractPosition;
+        }
+
+        private static Vector3? GetNearbyNavMeshPoint(Vector3 testPoint, float radius)
+        {
+            if (NavMesh.SamplePosition(testPoint, out var hit, radius, -1))
+            {
+                return hit.position;
+            }
+
+            return null;
+        }
+
+        private Vector3? FindNearestSpawnPointPosition(Vector3 testPoint)
+        {
+            if (NearestSpawnPosition != null)
+            {
+                return NearestSpawnPosition;
+            }
+
+            BotSpawner botSpawnerClass = Singleton<IBotGame>.Instance.BotsController.BotSpawner;
+            BotZone closestBotZone = botSpawnerClass.GetClosestZone(testPoint, out float dist);
+
+            IEnumerable<ISpawnPoint> sortedSpawnPoints = closestBotZone.SpawnPoints.OrderBy(x => Vector3.Distance(x.Position, testPoint));
+            if (!sortedSpawnPoints.Any())
+            {
+                return null;
+            }
+
+            NearestSpawnPosition = sortedSpawnPoints.First().Position;
+
+            return NearestSpawnPosition;
+        }
+    }
+}

--- a/Components/SAINGameworldComponent.cs
+++ b/Components/SAINGameworldComponent.cs
@@ -48,7 +48,9 @@ namespace SAIN.Components
             }
 
             SpawnPointMarkers = UnityEngine.Object.FindObjectsOfType<SpawnPointMarker>();
-            Logger.LogInfo($"Found {SpawnPointMarkers.Length} spawn point markers");
+
+            if (SAINPlugin.DebugMode)
+                Logger.LogInfo($"Found {SpawnPointMarkers.Length} spawn point markers");
         }
 
         public GameWorld GameWorld => Singleton<GameWorld>.Instance;

--- a/Components/SAINGameworldComponent.cs
+++ b/Components/SAINGameworldComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Comfort.Common;
 using EFT;
+using EFT.Game.Spawning;
 using SAIN.Components.BotController;
 using SAIN.Helpers;
 using System;
@@ -22,6 +23,8 @@ namespace SAIN.Components
         private void Update()
         {
             //SAINMainPlayer = ComponentHelpers.AddOrDestroyComponent(SAINMainPlayer, GameWorld?.MainPlayer);
+
+            findSpawnPointMarkers();
         }
 
         private void OnDestroy()
@@ -37,10 +40,22 @@ namespace SAIN.Components
             }
         }
 
+        private void findSpawnPointMarkers()
+        {
+            if ((SpawnPointMarkers != null) || (Camera.main == null))
+            {
+                return;
+            }
+
+            SpawnPointMarkers = UnityEngine.Object.FindObjectsOfType<SpawnPointMarker>();
+            Logger.LogInfo($"Found {SpawnPointMarkers.Length} spawn point markers");
+        }
+
         public GameWorld GameWorld => Singleton<GameWorld>.Instance;
-        public SAINMainPlayerComponent SAINMainPlayer { get; private set; }
-        public SAINBotControllerComponent SAINBotController { get; private set; }
-        public Extract.ExtractFinderComponent ExtractFinder { get; private set; }
+        public SAINMainPlayerComponent SAINMainPlayer { get; private set; } = null;
+        public SAINBotControllerComponent SAINBotController { get; private set; } = null;
+        public Extract.ExtractFinderComponent ExtractFinder { get; private set; } = null;
+        public SpawnPointMarker[] SpawnPointMarkers { get; private set; } = null;
     }
 
 }

--- a/Components/SAINGameworldComponent.cs
+++ b/Components/SAINGameworldComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Comfort.Common;
 using EFT;
+using SAIN.Components.BotController;
 using SAIN.Helpers;
 using System;
 using System.Collections.Generic;
@@ -15,6 +16,7 @@ namespace SAIN.Components
         private void Awake()
         {
             SAINBotController = this.GetOrAddComponent<SAINBotControllerComponent>();
+            ExtractFinder = this.GetOrAddComponent<Extract.ExtractFinderComponent>();
         }
 
         private void Update()
@@ -38,6 +40,7 @@ namespace SAIN.Components
         public GameWorld GameWorld => Singleton<GameWorld>.Instance;
         public SAINMainPlayerComponent SAINMainPlayer { get; private set; }
         public SAINBotControllerComponent SAINBotController { get; private set; }
+        public Extract.ExtractFinderComponent ExtractFinder { get; private set; }
     }
 
 }

--- a/Components/SAINGameworldComponent.cs
+++ b/Components/SAINGameworldComponent.cs
@@ -53,6 +53,22 @@ namespace SAIN.Components
                 Logger.LogInfo($"Found {SpawnPointMarkers.Length} spawn point markers");
         }
 
+        public IEnumerable<Vector3> GetAllSpawnPointPositionsOnNavMesh()
+        {
+            List<Vector3> spawnPointPositions = new List<Vector3>();
+            foreach (SpawnPointMarker spawnPointMarker in SpawnPointMarkers)
+            {
+                // Try to find a point on the NavMesh nearby the spawn point
+                Vector3? spawnPointPosition = NavMeshHelpers.GetNearbyNavMeshPoint(spawnPointMarker.Position, 2);
+                if (spawnPointPosition.HasValue && !spawnPointPositions.Contains(spawnPointPosition.Value))
+                {
+                    spawnPointPositions.Add(spawnPointPosition.Value);
+                }
+            }
+
+            return spawnPointPositions;
+        }
+
         public GameWorld GameWorld => Singleton<GameWorld>.Instance;
         public SAINMainPlayerComponent SAINMainPlayer { get; private set; } = null;
         public SAINBotControllerComponent SAINBotController { get; private set; } = null;

--- a/Helpers/NavMeshHelpers.cs
+++ b/Helpers/NavMeshHelpers.cs
@@ -13,9 +13,7 @@ namespace SAIN.Helpers
         public static bool DoesCompletePathExist(Vector3 sourcePosition, Vector3 targetPosition)
         {
             NavMeshPath path = new NavMeshPath();
-            NavMesh.CalculatePath(sourcePosition, targetPosition, -1, path);
-
-            return path.status == NavMeshPathStatus.PathComplete;
+            return NavMesh.CalculatePath(sourcePosition, targetPosition, -1, path) && (path.status == NavMeshPathStatus.PathComplete);
         }
 
         public static Vector3? GetNearbyNavMeshPoint(Vector3 testPoint, float radius)
@@ -42,23 +40,24 @@ namespace SAIN.Helpers
             float minExtent = Math.Min(Math.Min(bounds.size.x, bounds.size.x), bounds.size.x) / 2;
             if (minExtent < radius)
             {
-                if (SAINPlugin.DebugMode)
-                    Logger.LogWarning($"Radius {radius} is smaller than min bounds extent {minExtent}");
-                
+                Logger.LogError($"Radius {radius} is smaller than min bounds extent {minExtent} of size {bounds.size}");
+
                 return Enumerable.Empty<Vector3>();
             }
 
-            Vector3 origin = new Vector3(bounds.min.x + radius, bounds.min.y + radius, bounds.min.z + radius);
-
+            // Determine the number of points to place on each axis
             int widthCount = (int)Math.Max(1, Math.Ceiling((bounds.size.x - (radius * 2)) * densityFactor / (2 * radius)));
             int lengthCount = (int)Math.Max(1, Math.Ceiling((bounds.size.z - (radius * 2)) * densityFactor / (2 * radius)));
             int heightCount = (int)Math.Max(1, Math.Ceiling((bounds.size.y - (radius * 2)) * densityFactor / (2 * radius)));
 
+            // Determine the spacing of the points on each axis
             float widthSpacing = Math.Max(0, (bounds.size.x - (radius * 2)) / widthCount);
             float lengthSpacing = Math.Max(0, (bounds.size.z - (radius * 2)) / lengthCount);
             float heightSpacing = Math.Max(0, (bounds.size.y - (radius * 2)) / heightCount);
 
+            // Create a 3D mesh of points within the bounds
             List<Vector3> testPoints = new List<Vector3>();
+            Vector3 origin = new Vector3(bounds.min.x + radius, bounds.min.y + radius, bounds.min.z + radius);
             for (int x = 0; x <= widthCount; x++)
             {
                 for (int y = 0; y <= heightCount; y++)

--- a/Helpers/NavMeshHelpers.cs
+++ b/Helpers/NavMeshHelpers.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.AI;
+using UnityEngine;
+
+namespace SAIN.Helpers
+{
+    public static class NavMeshHelpers
+    {
+        public static bool DoesCompletePathExist(Vector3 sourcePosition, Vector3 targetPosition)
+        {
+            NavMeshPath path = new NavMeshPath();
+            NavMesh.CalculatePath(sourcePosition, targetPosition, -1, path);
+
+            return path.status == NavMeshPathStatus.PathComplete;
+        }
+
+        public static IEnumerable<Vector3> GetNavMeshTestPoints(this BoxCollider collider, float radius, float densityFactor)
+        {
+            // The Bounds for exfiltration colliders are junk in EFT, so we need to regenerate them here
+            Bounds colliderBounds = new Bounds(collider.transform.position, collider.size);
+
+            IEnumerable<Vector3> colliderTestPoints = GetNavMeshTestPoints(colliderBounds, radius, densityFactor);
+            return colliderTestPoints;
+        }
+
+        public static IEnumerable<Vector3> GetNavMeshTestPoints(this Bounds bounds, float radius, float densityFactor)
+        {
+            float minExtent = Math.Min(Math.Min(bounds.size.x, bounds.size.x), bounds.size.x) / 2;
+            if (minExtent < radius)
+            {
+                if (SAINPlugin.DebugMode)
+                    Logger.LogWarning($"Radius {radius} is smaller than min bounds extent {minExtent}");
+                
+                return Enumerable.Empty<Vector3>();
+            }
+
+            Vector3 origin = new Vector3(bounds.min.x + radius, bounds.min.y + radius, bounds.min.z + radius);
+
+            int widthCount = (int)Math.Max(1, Math.Ceiling((bounds.size.x - (radius * 2)) * densityFactor / (2 * radius)));
+            int lengthCount = (int)Math.Max(1, Math.Ceiling((bounds.size.z - (radius * 2)) * densityFactor / (2 * radius)));
+            int heightCount = (int)Math.Max(1, Math.Ceiling((bounds.size.y - (radius * 2)) * densityFactor / (2 * radius)));
+
+            float widthSpacing = Math.Max(0, (bounds.size.x - (radius * 2)) / widthCount);
+            float lengthSpacing = Math.Max(0, (bounds.size.z - (radius * 2)) / lengthCount);
+            float heightSpacing = Math.Max(0, (bounds.size.y - (radius * 2)) / heightCount);
+
+            List<Vector3> testPoints = new List<Vector3>();
+            for (int x = 0; x <= widthCount; x++)
+            {
+                for (int y = 0; y <= heightCount; y++)
+                {
+                    for (int z = 0; z <= lengthCount; z++)
+                    {
+                        testPoints.Add(new Vector3(origin.x + (widthSpacing * x), origin.y + (heightSpacing * y), origin.z + (lengthSpacing * z)));
+                    }
+                }
+            }
+
+            return testPoints;
+        }
+    }
+}

--- a/Helpers/NavMeshHelpers.cs
+++ b/Helpers/NavMeshHelpers.cs
@@ -18,6 +18,16 @@ namespace SAIN.Helpers
             return path.status == NavMeshPathStatus.PathComplete;
         }
 
+        public static Vector3? GetNearbyNavMeshPoint(Vector3 testPoint, float radius)
+        {
+            if (NavMesh.SamplePosition(testPoint, out var hit, radius, -1))
+            {
+                return hit.position;
+            }
+
+            return null;
+        }
+
         public static IEnumerable<Vector3> GetNavMeshTestPoints(this BoxCollider collider, float radius, float densityFactor)
         {
             // The Bounds for exfiltration colliders are junk in EFT, so we need to regenerate them here

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -25,7 +25,7 @@ namespace SAIN.Layers
                 return false;
             }
 
-            if (!BotController.BotExtractManager.IsBotAllowedToExfil(SAIN))
+            if (!Components.BotController.BotExtractManager.IsBotAllowedToExfil(SAIN))
             {
                 return false;
             }

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -43,7 +43,7 @@ namespace SAIN.Layers
 
             // If the bot can no longer use its selected extract and isn't already in the extract area, select another one. This typically happens if
             // the bot selects a VEX but the car leaves before the bot reaches it.
-            if (!BotController.BotExtractManager.CanUseExtract(SAIN.Memory.ExfilPoint) && !IsInExtractArea())
+            if (!BotController.BotExtractManager.CanBotsUseExtract(SAIN.Memory.ExfilPoint) && !IsInExtractArea())
             {
                 SAIN.Memory.ExfilPoint = null;
                 SAIN.Memory.ExfilPosition = null;

--- a/Plugin/External.cs
+++ b/Plugin/External.cs
@@ -24,9 +24,25 @@ namespace SAIN.Plugin
 
             component.Info.ForceExtract = true;
 
+            return true;
+        }
+
+        public static bool TrySetExfilForBot(BotOwner bot)
+        {
+            var component = bot.GetComponent<SAINComponentClass>();
+            if (component == null)
+            {
+                return false;
+            }
+
+            if (!Components.BotController.BotExtractManager.IsBotAllowedToExfil(component))
+            {
+                Logger.LogWarning($"{bot.name} is not allowed to use extracting logic.");
+            }
+
             if (!SAINPlugin.BotController.BotExtractManager.TryFindExfilForBot(component))
             {
-                Logger.LogWarning($"May not be able to force {bot.name} to extract; no exfils currently available.");
+                return false;
             }
 
             return true;

--- a/Plugin/External.cs
+++ b/Plugin/External.cs
@@ -24,6 +24,11 @@ namespace SAIN.Plugin
 
             component.Info.ForceExtract = true;
 
+            if (!SAINPlugin.BotController.BotExtractManager.TryFindExfilForBot(component))
+            {
+                Logger.LogWarning($"May not be able to force {bot.name} to extract; no exfils currently available.");
+            }
+
             return true;
         }
 

--- a/Plugin/SAINInterop.cs
+++ b/Plugin/SAINInterop.cs
@@ -17,7 +17,9 @@ namespace SAIN.Plugin
 
         private static bool _IsSAINLoaded;
         private static Type _SAINExternalType;
+
         private static MethodInfo _ExtractBotMethod;
+        private static MethodInfo _SetExfilForBotMethod;
         private static MethodInfo _ResetDecisionsForBotMethod;
 
         /**
@@ -53,6 +55,7 @@ namespace SAIN.Plugin
                 if (_SAINExternalType != null)
                 {
                     _ExtractBotMethod = AccessTools.Method(_SAINExternalType, "ExtractBot");
+                    _SetExfilForBotMethod = AccessTools.Method(_SAINExternalType, "TrySetExfilForBot");
                     _ResetDecisionsForBotMethod = AccessTools.Method(_SAINExternalType, "ResetDecisionsForBot");
                 }
             }
@@ -62,7 +65,7 @@ namespace SAIN.Plugin
         }
 
         /**
-         * Force a bot into the Extract layer if SAIN is loaded. Return true if the bot was set to extract
+         * Force a bot into the Extract layer if SAIN is loaded. Return true if the bot was set to extract.
          */
         public static bool TryExtractBot(BotOwner botOwner)
         {
@@ -73,7 +76,18 @@ namespace SAIN.Plugin
         }
 
         /**
-         * Force a bot to reset its decisions if SAIN is loaded. Return true if successful
+         * Try to select an exfil point for the bot if SAIN is loaded. Return true if an exfil was assigned to the bot.
+         */
+        public static bool TrySetExfilForBot(BotOwner botOwner)
+        {
+            if (!Init()) return false;
+            if (_SetExfilForBotMethod == null) return false;
+
+            return (bool)_SetExfilForBotMethod.Invoke(null, new object[] { botOwner });
+        }
+
+        /**
+         * Force a bot to reset its decisions if SAIN is loaded. Return true if successful.
          */
         public static bool TryResetDecisionsForBot(BotOwner botOwner)
         {

--- a/SAIN.csproj
+++ b/SAIN.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Attributes\AttributesInfoClass.cs" />
     <Compile Include="Attributes\GUIEntryConfig.cs" />
     <Compile Include="BotController\Classes\BotSquads.cs" />
+    <Compile Include="Components\Extract\ExtractFinderComponent.cs" />
     <Compile Include="Components\MainPlayer\BaseMainPlayer.cs" />
     <Compile Include="Components\MainPlayer\SAINCamoClass.cs" />
     <Compile Include="Components\MainPlayer\SAINMainPlayerComponent.cs" />
@@ -249,7 +250,9 @@
     <Compile Include="Editor\Util\ModifyLists.cs" />
     <Compile Include="Helpers\ComponentHelpers.cs" />
     <Compile Include="Helpers\Extensions.cs" />
+    <Compile Include="Components\Extract\ExtractPositionFinder.cs" />
     <Compile Include="Helpers\ListHelpers.cs" />
+    <Compile Include="Helpers\NavMeshHelpers.cs" />
     <Compile Include="Helpers\UpdateSettingClass.cs" />
     <Compile Include="Layers\DebugOverlay.cs" />
     <Compile Include="Layers\SAINAction.cs" />


### PR DESCRIPTION
**Overview of Changes:**
* Replaced simple 10m search around exfil colliders with a more complex system that algorithmically selects extract positions within the exfil collider. This fixes problems with SAIN being unable to resolve some extracts and it sometimes selecting extract points outside of the exfil collider. For example, bots were extracting via ZB-014 on Woods, but their extract position was on the ground above the bunker. See details below. 
* Extract pathing is now checked from static points on the map instead of from each bot. This should significantly improve performance after the first few search cycles because redundant searches are mostly eliminated. This system was separated from `BotExtractManager` into its own component (`ExtractFinderComponent`) because the classes serve different purposes. 
* Extract positions and the selected pathing endpoints for them can be viewed in the game by turning on debug mode and gizmos in the F12 menu for SAIN. 
* Extracts are assigned on-demand so pathing can be checked before the bot attempts to extract
* Added an interop command to try and set an exfil point for a bot. This allows mods like Questing Bots to instruct bots to extract but first check if an exfil can be assigned for them before deciding their next action. 

**Extract Position-Search Algorithm:**
1. A 3D mesh of test points is created within the exfil collider bounds. The density of the points is automatically adjusted to be a compromise between accuracy and performance. 
2. Each point in the mesh is tested to see if a nearby NavMesh intersection exists. These intersection points are added into a separate collection that is cached. That way, the mesh generation only happens once per exfil. 
3. The intersection points are copied to a `Stack`, and they're ordered so they're as far as possible from the previous point. The last point added to the `Stack` is the central-most point in the collider so it will be tested first.
4. Each time SAIN tries searching for extracts (currently every 10s), it retrieves the next intersection point from the `Stack`. Then, a certain number of spawn points (currently 2) are selected which are closest to the intersection point. However, the spawn points must be a minimum distance from each other (currently 75m), and spawn points with different elevation from the extract test point are de-prioritized (proportional to the elevation difference). Multiple points are used in case pathing is difficult from the first one selected. For example, the first spawn point that was typically getting selected for the VEX on Lighthouse was on the roof of one of the WTP buildings, and Unity always failed to calculate a path from it. 
5. SAIN checks if a complete path can be calculated between the intersection point and each of the selected spawn points. Only one pathing check can run per frame so the performance impact is minimized. 
6. If all intersection points are exhausted, the `Stack` is rebuilt from the cached points in step (2), and the pathing checks repeat. This is done throughout the raid in case a locked room opens that allows bots to extract in it (i.e. ZB-013 and ZB-014). 
7. Once a complete path is found for the exfil, no other checks are performed on it, and bots are allowed to use it for the rest of the raid