### PR TITLE
Select New Fallback Cover Points as Bots Travel

### DIFF
--- a/SAINComponent/SubComponents/CoverFinder/CoverFinderComponent.cs
+++ b/SAINComponent/SubComponents/CoverFinder/CoverFinderComponent.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
-using SAIN.BotController.Classes;
 
 namespace SAIN.SAINComponent.SubComponents.CoverFinder
 {
@@ -199,9 +198,10 @@ namespace SAIN.SAINComponent.SubComponents.CoverFinder
             }
         }
 
+        static float FallBackPointResetDistance = 35;
         static float FallBackPointNextAllowedResetDelayTime = 3f;
         static float FallBackPointNextAllowedResetTime = 0;
-
+        
         private void CheckResetFallback()
         {
             if (FallBackPoint == null || Time.time < FallBackPointNextAllowedResetTime)
@@ -209,10 +209,10 @@ namespace SAIN.SAINComponent.SubComponents.CoverFinder
                 return;
             }
 
-            if ((BotOwner.Position - FallBackPoint.Position).magnitude > 35)
+            if ((BotOwner.Position - FallBackPoint.Position).magnitude > FallBackPointResetDistance)
             {
-                //if (SAINPlugin.DebugMode)
-                Logger.LogInfo($"Resetting fallback point for {BotOwner.name}...");
+                if (SAINPlugin.DebugMode)
+                    Logger.LogInfo($"Resetting fallback point for {BotOwner.name}...");
 
                 FallBackPoint = null;
                 FallBackPointNextAllowedResetTime = Time.time + FallBackPointNextAllowedResetDelayTime;

--- a/SAINComponent/SubComponents/CoverFinder/CoverFinderComponent.cs
+++ b/SAINComponent/SubComponents/CoverFinder/CoverFinderComponent.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
+using SAIN.BotController.Classes;
 
 namespace SAIN.SAINComponent.SubComponents.CoverFinder
 {
@@ -179,11 +180,7 @@ namespace SAIN.SAINComponent.SubComponents.CoverFinder
 
         private void FindFallback()
         {
-            if ((FallBackPoint != null) && ((OriginPoint - FallBackPoint.Position).magnitude > 50))
-            {
-                Logger.LogInfo($"Resetting fallback point for {BotOwner.name}...");
-                FallBackPoint = null;
-            }
+            CheckResetFallback();
 
             if (CoverPoints.Count > 0 && FallBackPoint == null)
             {
@@ -199,6 +196,26 @@ namespace SAIN.SAINComponent.SubComponents.CoverFinder
                     }
                 }
                 FallBackPoint = CoverPoints[highestIndex];
+            }
+        }
+
+        static float FallBackPointNextAllowedResetDelayTime = 3f;
+        static float FallBackPointNextAllowedResetTime = 0;
+
+        private void CheckResetFallback()
+        {
+            if (FallBackPoint == null || Time.time < FallBackPointNextAllowedResetTime)
+            {
+                return;
+            }
+
+            if ((BotOwner.Position - FallBackPoint.Position).magnitude > 35)
+            {
+                //if (SAINPlugin.DebugMode)
+                Logger.LogInfo($"Resetting fallback point for {BotOwner.name}...");
+
+                FallBackPoint = null;
+                FallBackPointNextAllowedResetTime = Time.time + FallBackPointNextAllowedResetDelayTime;
             }
         }
 

--- a/SAINComponent/SubComponents/CoverFinder/CoverFinderComponent.cs
+++ b/SAINComponent/SubComponents/CoverFinder/CoverFinderComponent.cs
@@ -179,6 +179,12 @@ namespace SAIN.SAINComponent.SubComponents.CoverFinder
 
         private void FindFallback()
         {
+            if ((FallBackPoint != null) && ((OriginPoint - FallBackPoint.Position).magnitude > 50))
+            {
+                Logger.LogInfo($"Resetting fallback point for {BotOwner.name}...");
+                FallBackPoint = null;
+            }
+
             if (CoverPoints.Count > 0 && FallBackPoint == null)
             {
                 float highest = 0f;

--- a/SAINComponent/SubComponents/GrenadeTrackerComponent.cs
+++ b/SAINComponent/SubComponents/GrenadeTrackerComponent.cs
@@ -31,7 +31,7 @@ namespace SAIN.SAINComponent.SubComponents
 
         private bool EnemyGrenadeHeard()
         {
-            if (BotOwner.IsDead || Grenade == null)
+            if (BotOwner == null || BotOwner.IsDead || Grenade == null)
             {
                 return false;
             }


### PR DESCRIPTION
When using Questing Bots, bots will sometimes run a long distance to find cover. To fix this, this PR resets their fallback cover point if it's more than 35m away. This change also includes a 3s debounce timer to prevent it from constantly running if the new fallback cover point is outside the 35m threshold. I didn't think it was necessary to make the 35m threshold configurable, but feel free to add it to SAIN's configuration options if you'd like. 

As a bonus, this PR also includes a bug fix for NRE's when SAIN checks if dead or despawned bots can hear grenades. 